### PR TITLE
Feature/dns prims fixes

### DIFF
--- a/clx/dns/dns_extractor.py
+++ b/clx/dns/dns_extractor.py
@@ -11,7 +11,7 @@ log = logging.getLogger(__name__)
 class DnsVarsProvider:
     def __init__(self):
         self.__suffix_df = self.__load_suffix_df()
-        self.__allowed_output_cols = ["hostname", "subdomain", "domain", "suffix"]
+        self.__allowed_output_cols = {"hostname", "subdomain", "domain", "suffix"}
 
     @property
     def suffix_df(self):
@@ -25,7 +25,7 @@ class DnsVarsProvider:
         suffix_list_path = "%s/resources/suffix_list.txt" % os.path.dirname(
             os.path.realpath(__file__)
         )
-        log.info("Read suffix data at location %s." %(suffix_list_path))
+        log.info("Read suffix data at location %s." % (suffix_list_path))
         # Read suffix list csv file
         suffix_df = cudf.io.csv.read_csv(
             suffix_list_path, names=["suffix"], header=None, dtype=["str"]
@@ -44,21 +44,19 @@ def extract_hostnames(url_df_col):
         output: 
             ["www.worldbank.org.kg", "waiterrant.blogspot.com","b.cnn.com", "a.news.uk"]
     """
-    hostnames = url_df_col.str.extract("([\\w]+[\\.].+*[^/]")[0].str.extract(
-        "([\\w\\.]+)"
-    )[0]
+    hostnames = url_df_col.str.extract("([\\w]+[\\.].+*[^/]|[\\-\\w]+[\\.].+*[^/])")[
+        0
+    ].str.extract("([\\w\\.\\-]+)")[0]
     return hostnames
 
 
 def get_hostname_split_df(hostnames):
     # Find all words and digits between periods.
-    hostname_split = hostnames.str.findall("([\\w]+)")
+    hostname_split = hostnames.str.findall("([^.]+)")
     hostname_split_df = DataFrame()
     # Assign hostname split to cudf dataframe.
     for i in range(len(hostname_split) - 1, -1, -1):
         hostname_split_df[i] = hostname_split[i]
-    # Replace null column value with empty since merge operation may use all columns.
-    hostname_split_df = hostname_split_df.fillna("")
     return hostname_split_df
 
 
@@ -85,6 +83,7 @@ def generate_tld_cols(hostname_split_df, hostnames, col_len):
         output: 
             tld4 = ac
     """
+    hostname_split_df = hostname_split_df.fillna("")
     hostname_split_df["tld" + str(col_len)] = hostname_split_df[col_len]
     # Add all other elements of hostname_split_df
     for j in range(col_len - 1, 0, -1):
@@ -98,7 +97,7 @@ def generate_tld_cols(hostname_split_df, hostnames, col_len):
     return hostname_split_df
 
 
-def _extract_tld(input_df, suffix_df, col_len, output_df):
+def _extract_tld(input_df, suffix_df, col_len, col_dict, output_df):
     """
     Example:- 
         input:
@@ -108,14 +107,15 @@ def _extract_tld(input_df, suffix_df, col_len, output_df):
             2                      com        cnn           b                            com              cnn.com                   b.cnn.com
     
         output:
-                              hostname      domain        suffix  sd_prefix  sd_suffix
-            0   forums.news.cnn.com.ac         cnn        com.ac     forums       news
-            1       forums.news.cnn.ac         cnn            ac     forums       news
-            2                b.cnn.com         cnn           com          b           
+                              hostname      domain        suffix       subdomain
+            0   forums.news.cnn.com.ac         cnn        com.ac     forums.news
+            1       forums.news.cnn.ac         cnn            ac     forums.news
+            2                b.cnn.com         cnn           com               b           
     """
+
     tmp_suffix_df = DataFrame()
     # Iterating over each tld column starting from tld0 until it finds a match.
-    for i in range(col_len):
+    for i in range(col_len + 1):
         tld_col = "tld" + str(i)
         tmp_suffix_df[tld_col] = suffix_df["suffix"]
         # Left outer join input_df with tmp_suffix_df on tld column for each iteration.
@@ -126,39 +126,54 @@ def _extract_tld(input_df, suffix_df, col_len, output_df):
         tld_r_col = "tld%s_y" % (str(col_pos))
         # Check for a right side column i.e, added to merged_df when join clause satisfies.
         if tld_r_col in merged_df.columns:
-            temp_df = DataFrame()
             # Retrieve records which satisfies join clause.
             joined_recs_df = merged_df[merged_df[tld_r_col].isna() == False]
-            temp_df["hostname"] = joined_recs_df["tld0"]
-            temp_df["domain"] = joined_recs_df[col_pos]
-            temp_df["suffix"] = joined_recs_df[tld_r_col]
-            # Assigning values to construct subdomain at the end.
-            if col_pos == 0:
-                temp_df["sd_prefix"] = ""
-            else:
-                temp_df["sd_prefix"] = joined_recs_df[0]
-            if col_pos > 1:
-                temp_df["sd_suffix"] = joined_recs_df[1]
-            else:
-                temp_df["sd_suffix"] = ""
-            # Concat current iteration result to previous iteration result.
-            output_df = cudf.concat([temp_df, output_df])
-            # Assigning unprocessed records to input_df for next stage of processing.
-            input_df = merged_df[merged_df[tld_r_col].isna()]
+            if not joined_recs_df.empty:
+                temp_df = DataFrame()
+                if col_dict["hostname"]:
+                    temp_df["hostname"] = joined_recs_df["tld0"]
+                if col_dict["domain"]:
+                    temp_df["domain"] = joined_recs_df[col_pos]
+                if col_dict["suffix"]:
+                    temp_df["suffix"] = joined_recs_df[tld_r_col]
+                if col_dict["subdomain"]:
+                    temp_df["subdomain"] = ""
+                    if col_pos > 0:
+                        for idx in range(0, col_pos):
+                            temp_df["subdomain"] = temp_df["subdomain"].str.cat(
+                                joined_recs_df[idx], sep="."
+                            )
+                        temp_df["subdomain"] = (
+                            temp_df["subdomain"].str.replace(".^", "").str.lstrip(".")
+                        )
+                # Concat current iteration result to previous iteration result.
+                output_df = cudf.concat([temp_df, output_df])
+                # Assigning unprocessed records to input_df for next stage of processing.
+                if i < col_len:
+                    # Skip for last iteration. Since there won't be any entries to process further.
+                    input_df = merged_df[merged_df[tld_r_col].isna()]
     return output_df
 
 
-def _create_output_df():
+def _create_output_df(req_cols):
     """
     Create cuDF dataframe with set of predefined columns.
     """
-    output_df = DataFrame(
-        [
-            (col, "")
-            for col in ["domain", "suffix", "sd_prefix", "sd_suffix", "hostname"]
-        ]
-    )
+    output_df = DataFrame([(col, "") for col in req_cols])
+    # Remove empty record i.e, added while creating dataframe.
+    output_df = output_df[:0]
     return output_df
+
+
+def _create_col_dict(allowed_output_cols, req_cols):
+    """
+    Creates dictionary to apply check condition while extracting tld.
+    """
+    col_dict = {col: True for col in allowed_output_cols}
+    if req_cols != allowed_output_cols:
+        for col in allowed_output_cols ^ req_cols:
+            col_dict[col] = False
+    return col_dict
 
 
 def _verify_req_cols(req_cols, allowed_output_cols):
@@ -166,7 +181,7 @@ def _verify_req_cols(req_cols, allowed_output_cols):
     Verify user requested columns against allowed output columns.
     """
     if req_cols is not None:
-        if not set(req_cols).issubset(set(allowed_output_cols)):
+        if not req_cols.issubset(allowed_output_cols):
             raise ValueError(
                 "Given req_cols must be subset of %s" % (allowed_output_cols)
             )
@@ -180,8 +195,8 @@ def parse_url(url_df_col, req_cols=None):
     This function extracts subdomain, domain and suffix for a given url.
     returns: cuDF dataframe with requested columns. If req_cols values are passed as input parameter.
     Example:- 
-        requested cols: 
-            ["hostname", "domain", "suffix", "subdomain"]
+        requested cols:          
+            {"hostname", "domain", "suffix", "subdomain"}
         input:
                                         url
             0 http://forums.news.cnn.com.ac/
@@ -197,6 +212,7 @@ def parse_url(url_df_col, req_cols=None):
     # Singleton object.
     sv = DnsVarsProvider()
     req_cols = _verify_req_cols(req_cols, sv.allowed_output_cols)
+    col_dict = _create_col_dict(req_cols, sv.allowed_output_cols)
     hostnames = extract_hostnames(url_df_col)
     log.info("Extracting hostnames is successfully completed.")
     hostname_split_df = get_hostname_split_df(hostnames)
@@ -204,42 +220,12 @@ def parse_url(url_df_col, req_cols=None):
     log.info("Generating tld columns...")
     hostname_split_df = generate_tld_cols(hostname_split_df, hostnames, col_len)
     log.info("Successfully generated tld columns.")
-    output_df = _create_output_df()
+    output_df = _create_output_df(req_cols)
     log.info("Extracting tld...")
-    output_df = _extract_tld(hostname_split_df, sv.suffix_df, col_len, output_df)
-    log.info("Extracting tld is successfully completed.")
-    cleaned_output_df = _clean_output_df(output_df, req_cols)
-    return cleaned_output_df
-
-
-def _clean_output_df(output_df, req_cols):
-    """
-    Example:- 
-        requested cols: 
-            ["hostname", "domain", "suffix", "subdomain"]
-        input:
-                              hostname      domain        suffix  sd_prefix  sd_suffix
-            0   forums.news.cnn.com.ac         cnn        com.ac     forums       news
-            1       forums.news.cnn.ac         cnn            ac     forums       news
-            2                b.cnn.com         cnn           com          b           
-    
-        output:    
-                              hostname      domain        suffix    subdomain
-            0   forums.news.cnn.com.ac         cnn        com.ac  forums.news
-            1       forums.news.cnn.ac         cnn            ac  forums.news
-            2                b.cnn.com         cnn           com            b
-    """
-    clean_output_df = DataFrame()
+    output_df = _extract_tld(
+        hostname_split_df, sv.suffix_df, col_len, col_dict, output_df
+    )
     # reset index, since output_df is the result of multiple temp_df contactination.
     output_df = output_df.reset_index(drop=True)
-    # Remove empty record i.e, added while creating dataframe.
-    output_df = output_df[:-1]
-    # If required Concat sd_prefix and sd_suffix columns to generate subdomain.
-    if "subdomain" in req_cols:
-        output_df["subdomain"] = (
-            output_df["sd_prefix"]
-            .str.cat(output_df["sd_suffix"], sep=".")
-            .str.rstrip(".")
-        )
-    clean_output_df = output_df[req_cols]
-    return clean_output_df
+    log.info("Extracting tld is successfully completed.")
+    return output_df

--- a/clx/tests/test_dns_extractor.py
+++ b/clx/tests/test_dns_extractor.py
@@ -19,6 +19,8 @@ input_df = DataFrame(
                 "a.news.uk",
                 "a.news.co.uk",
                 "https://a.news.co.uk",
+                "107-193-100-2.lightspeed.cicril.sbcglobal.net",
+                "a23-44-13-2.deploy.static.akamaitechnologies.com",
             ],
         )
     ]
@@ -38,6 +40,8 @@ def test_parse_url(input_df):
             (
                 "domain",
                 [
+                    "sbcglobal",
+                    "akamaitechnologies",
                     "cnn",
                     "cnn",
                     "google",
@@ -55,6 +59,8 @@ def test_parse_url(input_df):
             (
                 "suffix",
                 [
+                    "net",
+                    "com",
                     "com.ac",
                     "ac",
                     "com",
@@ -71,7 +77,7 @@ def test_parse_url(input_df):
             ),
         ]
     )
-    output_df = dns.parse_url(input_df["url"], req_cols=["domain", "suffix"])
+    output_df = dns.parse_url(input_df["url"], req_cols={"domain", "suffix"})
     assert output_df.equals(expected_output_df)
 
 
@@ -82,6 +88,8 @@ def test2_parse_url(input_df):
             (
                 "hostname",
                 [
+                    "107-193-100-2.lightspeed.cicril.sbcglobal.net",
+                    "a23-44-13-2.deploy.static.akamaitechnologies.com",
                     "forums.news.cnn.com.ac",
                     "forums.news.cnn.ac",
                     "www.google.com",
@@ -99,6 +107,8 @@ def test2_parse_url(input_df):
             (
                 "subdomain",
                 [
+                    "107-193-100-2.lightspeed.cicril",
+                    "a23-44-13-2.deploy.static",
                     "forums.news",
                     "forums.news",
                     "www",
@@ -116,6 +126,8 @@ def test2_parse_url(input_df):
             (
                 "domain",
                 [
+                    "sbcglobal",
+                    "akamaitechnologies",
                     "cnn",
                     "cnn",
                     "google",
@@ -133,6 +145,8 @@ def test2_parse_url(input_df):
             (
                 "suffix",
                 [
+                    "net",
+                    "com",
                     "com.ac",
                     "ac",
                     "com",
@@ -172,6 +186,8 @@ def test_extract_hostname(input_df):
                     "a.news.uk",
                     "a.news.co.uk",
                     "a.news.co.uk",
+                    "107-193-100-2.lightspeed.cicril.sbcglobal.net",
+                    "a23-44-13-2.deploy.static.akamaitechnologies.com",
                 ],
             )
         ]
@@ -239,5 +255,5 @@ def test_parse_url_invalid_req_cols(input_df):
         % (["hostname", "subdomain", "domain", "suffix"])
     )
     with pytest.raises(ValueError) as actual_error:
-        output_df = dns.parse_url(input_df["url"], req_cols=["test"])
+        output_df = dns.parse_url(input_df["url"], req_cols={"test"})
         assert actual_error == expected_error


### PR DESCRIPTION
Added functionality to parse multilevel subdomain in dns Ex: `107-193-100-2.lightspeed.cicril.sbcglobal.net` subdomain value is `107-193-100-2.lightspeed.cicril`.