### PR TITLE
FIX Remove unused CUDA conda labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
  - PR #42 Include DNS parser in module
  - PR #41 Fix unit test
  - PR #39 Fix gpuCI builds
+ - PR #71 Remove unused CUDA conda labels
 
 
 # clx 0.10.0 (Date TBD)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
  - PR #43 Functionality to parse selected windows events
  - PR #46 Adding copyright
  - PR #53 Autogenerate api docs
+ - PR #71 Remove unused CUDA conda labels
 
 ## Bug Fixes
  - PR #69 Simple fix to DNS
@@ -27,7 +28,6 @@
  - PR #42 Include DNS parser in module
  - PR #41 Fix unit test
  - PR #39 Fix gpuCI builds
- - PR #71 Remove unused CUDA conda labels
 
 
 # clx 0.10.0 (Date TBD)

--- a/ci/cpu/upload-anaconda.sh
+++ b/ci/cpu/upload-anaconda.sh
@@ -7,7 +7,7 @@ CUDA_REL=${CUDA_VERSION%.*}
 
 SOURCE_BRANCH=master
 
-LABEL_OPTION="--label main --label cuda9.2 --label cuda10.0 --label cuda10.1"
+LABEL_OPTION="--label main"
 echo "LABEL_OPTION=${LABEL_OPTION}"
 
 # Restrict uploads to master branch


### PR DESCRIPTION
We no longer rely on these labels for version matching and use `cudatoolkit` package to do so.