### PR TITLE
Bug fix on file readers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
  - PR #71 Remove unused CUDA conda labels
 
 ## Bug Fixes
+ - PR #81 Reader filepath fix
  - PR #77 Fix to unit test
  - PR #69 Simple fix to DNS
  - PR #67 Fix DNS extra columns

--- a/clx/io/reader/dask_fs_reader.py
+++ b/clx/io/reader/dask_fs_reader.py
@@ -34,7 +34,7 @@ class DaskFileSystemReader(FileReader):
         """
         df = None
         input_format = self.config["input_format"].lower()
-        filepath = self.config["input_path"].lower()
+        filepath = self.config["input_path"]
         kwargs = self.config.copy()
         del kwargs["type"]
         del kwargs["input_format"]

--- a/clx/io/reader/fs_reader.py
+++ b/clx/io/reader/fs_reader.py
@@ -36,7 +36,7 @@ class FileSystemReader(FileReader):
         """
         df = None
         input_format = self.config["input_format"].lower()
-        filepath = self.config["input_path"].lower()
+        filepath = self.config["input_path"]
         kwargs = self.config.copy()
         del kwargs["type"]
         del kwargs["input_format"]


### PR DESCRIPTION
Removed `tolower()` on filepaths