### PR TITLE
[WIP] Fix alert analysis unit test and workflow notebook

### DIFF
--- a/clx/parsers/event_parser.py
+++ b/clx/parsers/event_parser.py
@@ -86,8 +86,9 @@ class EventParser(ABC):
         for col in event_specific_columns:
             regex_pattern = event_regex.get(col)
             extracted_nvstrings = dataframe[raw_column].str.extract(regex_pattern)
+            print("col", col, "strings", extracted_nvstrings[0], extracted_nvstrings[0].dtype)
             if not extracted_nvstrings.empty:
-                parsed_gdf[col] = extracted_nvstrings[0]
+                parsed_gdf[col] = extracted_nvstrings[0].str.fillna("")
 
         remaining_columns = list(self.columns - event_specific_columns)
         # Fill remaining columns with empty.

--- a/clx/parsers/event_parser.py
+++ b/clx/parsers/event_parser.py
@@ -80,13 +80,11 @@ class EventParser(ABC):
             + str(dataframe.shape)
         )
         parsed_gdf = cudf.DataFrame({col: [""] for col in self.columns})
-        parsed_gdf = parsed_gdf[:0]
         event_specific_columns = event_regex.keys()
         # Applies regex pattern for each expected output column to raw data
         for col in event_specific_columns:
             regex_pattern = event_regex.get(col)
             extracted_nvstrings = dataframe[raw_column].str.extract(regex_pattern)
-            print("col", col, "strings", extracted_nvstrings[0], extracted_nvstrings[0].dtype)
             if not extracted_nvstrings.empty:
                 parsed_gdf[col] = extracted_nvstrings[0].str.fillna("")
 

--- a/clx/parsers/splunk_notable_parser.py
+++ b/clx/parsers/splunk_notable_parser.py
@@ -49,8 +49,6 @@ class SplunkNotableParser(EventParser):
         # Cleaning raw data to be consistent.
         dataframe[raw_column] = dataframe[raw_column].str.replace("\\\\", "")
         parsed_dataframe = self.parse_raw_event(dataframe, raw_column, self.event_regex)
-        # Replace null values of all columns with empty.
-        parsed_dataframe = parsed_dataframe.fillna("")
         # Post-processing: for src_ip and dest_ip.
         parsed_dataframe = self._process_ip_fields(parsed_dataframe)
         return parsed_dataframe

--- a/notebooks/alert_analysis/workflow_implementation/CLX_Workflow_Notebook1.ipynb
+++ b/notebooks/alert_analysis/workflow_implementation/CLX_Workflow_Notebook1.ipynb
@@ -37,7 +37,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -46,7 +46,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -67,7 +67,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -80,7 +80,7 @@
     }
    ],
    "source": [
-    "!cat /clx/notebooks/alert_analysis/workflow_implementation/input.csv"
+    "!cat /rapids/clx/notebooks/alert_analysis/workflow_implementation/input.csv"
    ]
   },
   {
@@ -92,14 +92,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
     "source = {\n",
     "    \"type\": \"fs\",\n",
     "    \"input_format\": \"csv\",\n",
-    "    \"input_path\": \"/clx/notebooks/alert_analysis/workflow_implementation/input.csv\",\n",
+    "    \"input_path\": \"/rapids/clx/notebooks/alert_analysis/workflow_implementation/input.csv\",\n",
     "    \"schema\": [\"raw\"],\n",
     "    \"delimiter\": \",\",\n",
     "    \"usecols\": [\"raw\"],\n",
@@ -109,7 +109,7 @@
     "destination = {\n",
     "    \"type\": \"fs\",\n",
     "    \"output_format\": \"csv\",\n",
-    "    \"output_path\": \"/clx/notebooks/alert_analysis/workflow_implementation/output.csv\",\n",
+    "    \"output_path\": \"/rapids/clx/notebooks/alert_analysis/workflow_implementation/output.csv\",\n",
     "    \"index\": False\n",
     "}"
    ]
@@ -123,11 +123,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
-    "![ -e /clx/notebooks/alert_analysis/workflow_implementation/output.csv ] && rm /clx/notebooks/alert_analysis/workflow_implementation/output.csv\n",
+    "![ -e /rapids/clx/notebooks/alert_analysis/workflow_implementation/output.csv ] && rm /rapids/clx/notebooks/alert_analysis/workflow_implementation/output.csv\n",
     "workflow = TestWorkflowImpl(name=\"my-test-workflow\", source=source, destination=destination)\n",
     "workflow.run_workflow()"
    ]
@@ -141,7 +141,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -154,14 +154,7 @@
     }
    ],
    "source": [
-    "!cat /clx/notebooks/alert_analysis/workflow_implementation/output.csv"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "( Talk about how this can easily be deployed to production )"
+    "!cat /rapids/clx/notebooks/alert_analysis/workflow_implementation/output.csv"
    ]
   },
   {
@@ -187,7 +180,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -204,7 +197,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -226,7 +219,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -244,7 +237,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -268,7 +261,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -309,7 +302,7 @@
        "0    gtcdc"
       ]
      },
-     "execution_count": 36,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -343,7 +336,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -359,14 +352,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
     "source = {\n",
     "    \"type\": \"fs\",\n",
     "    \"input_format\": \"csv\",\n",
-    "    \"input_path\": \"/clx/notebooks/alert_analysis/workflow_implementation/input2.csv\",\n",
+    "    \"input_path\": \"/rapids/clx/notebooks/alert_analysis/workflow_implementation/input2.csv\",\n",
     "    \"schema\": [\"raw\"],\n",
     "    \"delimiter\": \",\",\n",
     "    \"required_cols\": [\"raw\"],\n",
@@ -376,7 +369,7 @@
     "destination = {\n",
     "    \"type\": \"fs\",\n",
     "    \"output_format\": \"csv\",\n",
-    "    \"output_path\": \"/clx/notebooks/alert_analysis/workflow_implementation/output2.csv\",\n",
+    "    \"output_path\": \"/rapids/clx/notebooks/alert_analysis/workflow_implementation/output2.csv\",\n",
     "    \"index\": False\n",
     "}"
    ]
@@ -390,7 +383,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -415,11 +408,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
-    "![ -e /clx/notebooks/alert_analysis/workflow_implementation/output2.csv ] && rm /clx/notebooks/alert_analysis/workflow_implementation/output2.csv\n",
+    "![ -e /rapids/clx/notebooks/alert_analysis/workflow_implementation/output2.csv ] && rm /rapids/clx/notebooks/alert_analysis/workflow_implementation/output2.csv\n",
     "workflow = TestWorkflowImpl(name=\"my-test-workflow\", source=source, destination=destination)\n",
     "workflow.run_workflow()"
    ]
@@ -433,7 +426,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -446,7 +439,7 @@
     }
    ],
    "source": [
-    "!cat /clx/notebooks/alert_analysis/workflow_implementation/output2.csv"
+    "!cat /rapids/clx/notebooks/alert_analysis/workflow_implementation/output2.csv"
    ]
   },
   {
@@ -473,7 +466,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
- Fixed `test_splunk_notable_parser.py` unit test failure by moving string `fillna` function to `event_parser.py`. All `None` values from regex parsing or `remaining_columns` will equal `""`
- Removed `parsed_gdf = parsed_gdf[:0]` from event_parser to fix error found in workflow notebook 
```ValueError: Length mismatch: Expected axis has 1 elements, new values have 0 elements```
- Changed filepaths in notebook to match new location of clx under `/rapids/clx`