### PR TITLE
[REVIEW] Add channel for pytorch cuda 10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - PR #120 Use pytest tmpdir fixtures in unit tests
 
 ## Bug Fixes
+- PR #224 Updates conda installs for CUDA 10.2
 
 
 # clx 0.12.0 (Date TBD)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - PR #120 Use pytest tmpdir fixtures in unit tests
 
 ## Bug Fixes
-- PR #224 Updates conda installs for CUDA 10.2
+- PR #124 Updates conda installs for CUDA 10.2
 
 
 # clx 0.12.0 (Date TBD)

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -47,7 +47,7 @@ conda config --set ssl_verify False
 conda install nvstrings=${MINOR_VERSION} cugraph=${MINOR_VERSION} dask-cudf=${MINOR_VERSION} \
    requests yaml python-confluent-kafka python-whois dask
 
-conda install -y pytorch==1.3.1 torchvision -c pytorch
+conda install -y pytorch==1.3.1 torchvision -c pytorch -c raydouglass
 
 pip install mockito
 pip install cupy-cuda${CUDA_SHORT}

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -47,7 +47,7 @@ conda config --set ssl_verify False
 conda install nvstrings=${MINOR_VERSION} cugraph=${MINOR_VERSION} dask-cudf=${MINOR_VERSION} \
    requests yaml python-confluent-kafka python-whois dask "cupy>=6.6.0,<8.0.0a0,!=7.1.0"
 
-conda install -y pytorch==1.3.1 torchvision -c pytorch -c raydouglass
+conda install -y pytorch==1.3.1 torchvision -c pytorch -c rapidsai/label/pytorch
 
 pip install mockito
 

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -50,7 +50,6 @@ conda install nvstrings=${MINOR_VERSION} cugraph=${MINOR_VERSION} dask-cudf=${MI
 conda install -y pytorch==1.3.1 torchvision -c pytorch -c raydouglass
 
 pip install mockito
-pip install cupy-cuda${CUDA_SHORT}
 
 conda list
 

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -45,7 +45,7 @@ g++ --version
 conda config --set ssl_verify False
 
 conda install nvstrings=${MINOR_VERSION} cugraph=${MINOR_VERSION} dask-cudf=${MINOR_VERSION} \
-   requests yaml python-confluent-kafka python-whois dask
+   requests yaml python-confluent-kafka python-whois dask "cupy>=6.6.0,<8.0.0a0,!=7.1.0"
 
 conda install -y pytorch==1.3.1 torchvision -c pytorch -c raydouglass
 


### PR DESCRIPTION
Adds our channel with CUDA 10.2 builds of pytorch. Also switch cupy install to use conda (to get CUDA 10.2 builds).