### PR TITLE
[REVIEW] gpu build fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - PR #150 Fix splunk alert workflow test
 - PR #154 Local gpuCI build fix
 - PR #158 Fix test cases to support latest cudf changes
+- PR #164 GPU build fix
 
 # clx 0.13.0 (Date TBD)
 

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -43,11 +43,10 @@ python --version
 conda config --set ssl_verify False
 
 logger "conda install required packages"
-conda install -y -c conda-forge -c rapidsai -c rapidsai-nightly -c nvidia \
+conda install \
     "cugraph=${MINOR_VERSION}" \
-    "cuxfilter=${MINOR_VERSION}" \
-    "dask>=2.8.0" \
-    "distributed>=2.8.0" \
+    "dask>=2.12.0" \
+    "distributed>=2.12.0" \
     "dask-cudf=${MINOR_VERSION}"
 
 # Install master version of cudatashader

--- a/conda/environments/clx_dev.yml
+++ b/conda/environments/clx_dev.yml
@@ -9,9 +9,8 @@ channels:
 - rapidsai/label/pytorch
 dependencies:
 - cugraph=0.14.*
-- cuxfilter=0.14.*
-- dask>=2.8.0
-- distributed>=2.8.0
+- dask>=2.12.0
+- distributed>=2.12.0
 - dask-cudf=0.14.*
 - pytorch==1.3.1
 - torchvision=0.4.2


### PR DESCRIPTION
Removed cuxfilter conda install from gpu build because it was causing conda resolver conflicts which would sometimes cause build timeouts in nightly matrix build.  cuxfilter was only used in demo notebook which is currently being skipped in notebook testing until we update to pytorch 1.5.