### PR TITLE
[gpuCI] Auto-merge branch-0.14 to branch-0.15 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# clx 0.14.0 (Date TBD)
+# clx 0.14.0 (03 Jun 2020)
 
 ## New Features
 - PR #141 CUDA BERT Tokenizer


### PR DESCRIPTION
Auto-merge triggered by push to `branch-0.14` that creates a PR to keep `branch-0.15` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.