### PR TITLE
Update documentation links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Improvements
 
 ## Bug Fixes
+- PR #169 Fix documentation links
 
 # clx 0.14.0 (Date TBD)
 

--- a/docs/source/intro-clx-workflow.ipynb
+++ b/docs/source/intro-clx-workflow.ipynb
@@ -134,7 +134,7 @@
     "#### Filesystem\n",
     "If the `fs` type is used, the developer must distinguish the data format using the `input_format` attribute. Formats available are: csv, parquet, and orc.\n",
     "  \n",
-    "The associated parameters available for the `fs` type and `input_format` are documented within the [cuDF I/O](https://rapidsai.github.io/projects/cudf/en/0.11.0/api.html#module-cudf.io.csv) API. For example for reading data from a csv file, reference [cudf.io.csv.read_csv](https://rapidsai.github.io/projects/cudf/en/0.11.0/api.html#cudf.io.csv.read_csv) available parameters.\n",
+    "The associated parameters available for the `fs` type and `input_format` are documented within the [cuDF I/O](https://docs.rapids.ai/api/cudf/0.11/api.html#module-cudf.io.csv) API. For example for reading data from a csv file, reference [cudf.io.csv.read_csv](https://docs.rapids.ai/api/cudf/0.11/api.html#cudf.io.csv.read_csv) available parameters.\n",
     "\n",
     "Example\n"
    ]
@@ -161,7 +161,7 @@
     "  \n",
     "If the `dask_fs` type is used the developer must distinguish the data format using the `input_format` attribute. Formats available are: csv, parquet, and orc.\n",
     "  \n",
-    "The associated parameters available for the `dask_fs` type and `input_format` are listed within the [Dask cuDF](https://rapidsai.github.io/projects/cudf/en/0.11.0/10min.html#Getting-Data-In/Out) documentation. \n",
+    "The associated parameters available for the `dask_fs` type and `input_format` are listed within the [Dask cuDF](https://docs.rapids.ai/api/cudf/0.11/10min.html#Getting-Data-In/Out) documentation. \n",
     "  \n",
     "Example"
    ]

--- a/notebooks/dga_detection/DGA_Detection.ipynb
+++ b/notebooks/dga_detection/DGA_Detection.ipynb
@@ -256,7 +256,7 @@
    "metadata": {},
    "source": [
     "#### Create Train and Test Dataset\n",
-    "We utilize the [`train_test_split` function](https://rapidsai.github.io/projects/cuml/en/0.10.0/api.html?highlight=train_test#model-selection-and-data-splitting) from [cuML](https://github.com/rapidsai/cuml) and create a shuffled dataset for training and testing."
+    "We utilize the [`train_test_split` function](https://docs.rapids.ai/api/cuml/0.10/api.html#model-selection-and-data-splitting) from [cuML](https://github.com/rapidsai/cuml) and create a shuffled dataset for training and testing."
    ]
   },
   {

--- a/notebooks/network_mapping/Network_Mapping_With_RAPIDS_And_CLX.ipynb
+++ b/notebooks/network_mapping/Network_Mapping_With_RAPIDS_And_CLX.ipynb
@@ -23,7 +23,7 @@
     "\n",
     "## Introduction\n",
     "\n",
-    "In this notebook, we show an example of how to create a network map from [Zeek](https://www.zeek.org) ([formerly known as Bro](https://blog.zeek.org/2018/10/renaming-bro-project_11.html)) log data. We then enrich the nodes in our graph using a [CLX](https://github.com/rapidsai/clx) port heuristic analytic and [cuGraph Pagerank](https://rapidsai.github.io/projects/cugraph/en/0.10.0/api.html#module-cugraph.link_analysis.pagerank). The data we use is a sample from the [UNSW-NB15 dataset](https://www.unsw.adfa.edu.au/unsw-canberra-cyber/cybersecurity/ADFA-NB15-Datasets/) which can be downloaded [here](https://cloudstor.aarnet.edu.au/plus/index.php/s/2DhnLGDdEECo4ys)."
+    "In this notebook, we show an example of how to create a network map from [Zeek](https://www.zeek.org) ([formerly known as Bro](https://blog.zeek.org/2018/10/renaming-bro-project_11.html)) log data. We then enrich the nodes in our graph using a [CLX](https://github.com/rapidsai/clx) port heuristic analytic and [cuGraph Pagerank](https://docs.rapids.ai/api/cugraph/0.10/api.html#module-cugraph.link_analysis.pagerank). The data we use is a sample from the [UNSW-NB15 dataset](https://www.unsw.adfa.edu.au/unsw-canberra-cyber/cybersecurity/ADFA-NB15-Datasets/) which can be downloaded [here](https://cloudstor.aarnet.edu.au/plus/index.php/s/2DhnLGDdEECo4ys)."
    ]
   },
   {


### PR DESCRIPTION
This PR updates all of the documentation links throughout the repo. The https://rapidsai.github.io/projects/ URLs are no longer valid.