### PR TITLE
[REVIEW] Install dependencies via meta package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## New Features
 
 ## Improvements
+- PR #174 Install dependencies via meta package
 
 ## Bug Fixes
 - PR #169 Fix documentation links

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -45,9 +45,12 @@ conda config --set ssl_verify False
 logger "conda install required packages"
 conda install \
     "cugraph=${MINOR_VERSION}" \
-    "dask>=2.12.0" \
-    "distributed>=2.12.0" \
-    "dask-cudf=${MINOR_VERSION}"
+    "dask-cudf=${MINOR_VERSION}" \
+    "rapids-build-env=$MINOR_VERSION.*"
+
+# https://docs.rapids.ai/maintainers/depmgmt/ 
+# conda remove -f rapids-build-env
+# conda install "your-pkg=1.0.0"
 
 # Install master version of cudatashader
 pip install "git+https://github.com/rapidsai/cudatashader.git"


### PR DESCRIPTION
Install dependencies via `rapids-build-env` (which is pre-installed in the containers).

This brings the repo in line with https://docs.rapids.ai/maintainers/depmgmt/