### PR TITLE
[REVIEW] Tokenizer updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## New Features
 
 ## Improvements
+- PR #175 GPU tokenizer updates
 
 ## Bug Fixes
 - PR #169 Fix documentation links

--- a/cpp/benchmarks/tokenizer_benchmark.cu
+++ b/cpp/benchmarks/tokenizer_benchmark.cu
@@ -2,7 +2,6 @@
 #include <for_cython.h>
 
 #include <thrust/device_vector.h>
-#include <rmm/rmm.h>
 #include <rmm/thrust_rmm_allocator.h>
 
 #define MAX_NUM_SENTENCES 101

--- a/cpp/cmake/Templates/GoogleBenchmark.CMakeLists.txt.cmake
+++ b/cpp/cmake/Templates/GoogleBenchmark.CMakeLists.txt.cmake
@@ -4,7 +4,7 @@ include(ExternalProject)
 
 ExternalProject_Add(GoogleBenchmark
                     GIT_REPOSITORY    https://github.com/google/benchmark.git
-                    GIT_TAG           master
+                    GIT_TAG           v1.5.1
                     SOURCE_DIR        "${GBENCH_ROOT}/googlebenchmark"
                     BINARY_DIR        "${GBENCH_ROOT}/build"
                     INSTALL_DIR		    "${GBENCH_ROOT}/install"

--- a/cpp/src/data_transfer_utils.cuh
+++ b/cpp/src/data_transfer_utils.cuh
@@ -4,7 +4,6 @@
 #include <iostream>
 
 #include <thrust/device_vector.h>
-#include <rmm/rmm.h>
 #include <rmm/thrust_rmm_allocator.h>
 
 inline void gpuCheck(cudaError_t err, const char *file, int line) {

--- a/cpp/src/tokenizers.cuh
+++ b/cpp/src/tokenizers.cuh
@@ -5,7 +5,6 @@
 #include <string>
 
 #include <thrust/device_vector.h>
-#include <rmm/rmm.h>
 #include <rmm/thrust_rmm_allocator.h>
 
 template<typename T>

--- a/cpp/tests/tokenizer_test.cu
+++ b/cpp/tests/tokenizer_test.cu
@@ -4,7 +4,6 @@
 #include <gtest/gtest.h>
 
 #include <thrust/device_vector.h>
-#include <rmm/rmm.h>
 #include <rmm/thrust_rmm_allocator.h>
 
 #define MAX_NUM_SENTENCES 101

--- a/python/clx/analytics/tokenizer_wrapper.pyx
+++ b/python/clx/analytics/tokenizer_wrapper.pyx
@@ -71,9 +71,7 @@ def tokenize_df(input_df, hash_file="default", max_sequence_length=64, stride=48
     else:
         raise ValueError("Input must be a cudf.DataFrame or cudf.Series")
 
-    d_arr=cupy.empty(len(input_df), dtype=np.uint32)
-    col.str.byte_count(d_arr.data.ptr,True)
-    offsets = cupy.asnumpy(d_arr)
+    offsets = col.str.byte_count().to_array()
 
     cdef TokenizerResult *result
     result = <TokenizerResult *>calloc(1,sizeof(TokenizerResult))

--- a/python/clx/tests/test_tokenizer.py
+++ b/python/clx/tests/test_tokenizer.py
@@ -1,0 +1,62 @@
+# Copyright (c) 2020, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import cudf
+import pytest
+import torch
+from clx.analytics import tokenizer
+
+input_sentence = "Key length indicates the length of the generated session key."
+
+expected_tokens = torch.tensor([[3145, 3091, 7127, 1996, 3091, 1997, 1996, 7013, 5219, 3145, 1012, 0,
+                                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                0, 0, 0, 0]], device="cuda")
+
+expected_masks = torch.tensor([[1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]], device='cuda')
+
+expected_metadata = torch.tensor([[0, 0, 10]], device="cuda")
+
+
+@pytest.mark.parametrize("input_sentence, expected_tokens, expected_masks, expected_metadata", [(input_sentence, expected_tokens, expected_masks, expected_metadata)])
+def test_tokenize_file(tmpdir, input_sentence, expected_tokens, expected_masks, expected_metadata):
+    fname = tmpdir.mkdir("tmp_test_tokenizer").join("test1.txt")
+    fname.write(input_sentence)
+
+    assert fname.read() == input_sentence
+
+    actual_tokens, actual_masks, actual_metadata = tokenizer.tokenize_file(str(fname))
+
+    assert actual_tokens.equal(expected_tokens)
+    assert actual_masks.equal(expected_masks)
+    assert actual_metadata.equal(expected_metadata)
+
+
+@pytest.mark.parametrize("input_sentence, expected_tokens, expected_masks, expected_metadata", [(input_sentence, expected_tokens, expected_masks, expected_metadata)])
+def test_tokenize_df(tmpdir, input_sentence, expected_tokens, expected_masks, expected_metadata):
+    fname = tmpdir.mkdir("tmp_test_tokenizer").join("test1.txt")
+    fname.write(input_sentence)
+
+    assert fname.read() == input_sentence
+
+    df = cudf.read_csv(fname, header=None)
+    actual_tokens, actual_masks, actual_metadata = tokenizer.tokenize_df(df)
+
+    assert actual_tokens.equal(expected_tokens)
+    assert actual_masks.equal(expected_masks)
+    assert actual_metadata.equal(expected_metadata)


### PR DESCRIPTION
- Remove deprecated rmm headers
- Update tokenizer to use cudf `byte_count` ported from nvstrings
- Add tokenizer unit test
- Google Benchmark fix