### PR TITLE
Update prebuild.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - PR #175 GPU tokenizer updates
 - PR #181 CLX Query to support dask blazingsql
 - PR #159 Update to PyTorch 1.5
+- PR #191 Update conda upload versions for new supported CUDA/Python
 
 ## Bug Fixes
 - PR #169 Fix documentation links

--- a/ci/cpu/prebuild.sh
+++ b/ci/cpu/prebuild.sh
@@ -3,13 +3,13 @@
 export BUILD_CLX=1
 export BUILD_LIBCLX=1
 
-if [[ "$CUDA" == "10.0" ]]; then
+if [[ "$CUDA" == "10.1" ]]; then
     export UPLOAD_CLX=1
 else
     export UPLOAD_CLX=0
 fi
 
-if [[ "$PYTHON" == "3.6" ]]; then
+if [[ "$PYTHON" == "3.7" ]]; then
     export UPLOAD_LIBCLX=1
 else
     export UPLOAD_LIBCLX=0


### PR DESCRIPTION
Update conda upload versions for new supported CUDA/Python

Edited ci/cpu/prebuild.sh with CUDA 10.1 and python 3.7 as new defaults.