### PR TITLE
[REVIEW] gpu build and dockerfile update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - PR #159 Update to PyTorch 1.5
 - PR #191 Update conda upload versions for new supported CUDA/Python
 - PR #203 CLX docker and conda environment updates
+- PR #209 GPU build and Dockerfile update
 
 ## Bug Fixes
 - PR #169 Fix documentation links

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,35 +1,25 @@
 # An integration test & dev container which builds and installs CLX from default branch
+ARG RAPIDS_VERSION=0.15
 ARG CUDA_VERSION=10.1
 ARG CUDA_SHORT_VERSION=${CUDA_VERSION}
 ARG LINUX_VERSION=ubuntu18.04
-FROM gpuci/miniconda-cuda:${CUDA_VERSION}-devel-${LINUX_VERSION}
-ENV DEBIAN_FRONTEND=noninteractive
-
-ARG CC=5
-ARG CXX=5
-
-RUN apt update -y --fix-missing && \
-    apt upgrade -y && \
-    apt install -y \
-      git \
-      gcc-${CC} \
-      g++-${CXX} \
-      libboost-all-dev \
-      tzdata
+ARG PYTHON_VERSION=3.7
+FROM rapidsai/rapidsai-dev-nightly:${RAPIDS_VERSION}-cuda${CUDA_VERSION}-devel-${LINUX_VERSION}-py${PYTHON_VERSION}
 
 # Add everything from the local build context
 ADD . /rapids/clx/
 
-RUN mkdir -p /rapids/utils 
-COPY ./docker/start_jupyter.sh ./docker/stop_jupyter.sh /rapids/utils/
+RUN apt update -y --fix-missing && \
+    apt upgrade -y
 
-ARG CUDA_SHORT_VERSION
-ARG PYTHON_VERSION=3.7
-RUN conda env create --name rapids --file /rapids/clx/conda/environments/clx_dev_cuda${CUDA_SHORT_VERSION}.yml python=${PYTHON_VERSION}
+RUN source activate rapids && \
+    conda install -c pytorch pytorch=1.5.* torchvision custreamz=${RAPIDS_VER} scikit-learn>=0.21 ipywidgets python-confluent-kafka transformers seqeval python-whois seaborn requests matplotlib pytest jupyterlab && \
+    pip install "git+https://github.com/rapidsai/cudatashader.git" && \
+    pip install mockito && \
+    pip install wget && \
+    pip install pytorch-transformers
 
 # libclx build/install
-ENV CC=/usr/bin/gcc-${CC}
-ENV CXX=/usr/bin/g++-${CXX}
 RUN source activate rapids && \
     mkdir -p /rapids/clx/cpp/build && \
     cd /rapids/clx/cpp/build && \
@@ -43,10 +33,3 @@ RUN source activate rapids && \
     python setup.py install
 
 WORKDIR /rapids/clx
-
-ENV TINI_VERSION v0.19.0
-ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /usr/bin/tini
-RUN chmod +x /usr/bin/tini && \
-    echo "source activate rapids" >> ~/.bashrc
-ENTRYPOINT [ "/usr/bin/tini", "--", "/rapids/clx/docker/.run_in_rapids.sh" ]
-CMD [ "/bin/bash" ]

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -42,35 +42,22 @@ python --version
 # FIX Added to deal with Anancoda SSL verification issues during conda builds
 conda config --set ssl_verify False
 
-conda remove nomkl blas libblas
-
 logger "conda install required packages"
 conda install -c pytorch -c gwerbin \
+    "rapids-build-env=$MINOR_VERSION.*" \
+    "rapids-notebook-env=$MINOR_VERSION.*" \
     "cugraph=${MINOR_VERSION}" \
     "cuml=${MINOR_VERSION}" \
     "dask-cudf=${MINOR_VERSION}" \
     "pytorch=1.5.*" \
     "torchvision" \
-    "scikit-learn" \
-    "numpy>=1.17.3,<1.19.0" \
     "python-confluent-kafka" \
     "transformers" \
     "seqeval" \
     "python-whois" \
     "requests" \
-    "cmake" \
-    "cython" \
-    "pytest" \
-    "s3fs" \
-    "ipython" \
-    "matplotlib" \
-    "nbconvert"
+    "matplotlib"
 
-# Install the master version of dask, distributed, and cudatashader
-logger "pip install git+https://github.com/dask/distributed.git --upgrade --no-deps"
-pip install "git+https://github.com/dask/distributed.git" --upgrade --no-deps
-logger "pip install git+https://github.com/dask/dask.git --upgrade --no-deps"
-pip install "git+https://github.com/dask/dask.git" --upgrade --no-deps
 logger "pip install git+https://github.com/rapidsai/cudatashader.git"
 pip install "git+https://github.com/rapidsai/cudatashader.git"
 logger "pip install mockito"


### PR DESCRIPTION
The rapidsai docker images were updated to allow install of mkl blas. This simplifies the install of clx/pytorch because we no longer need to remove nomkl and openblas beforehand. This PR updates the gpu build and dockerfile to reflect this.