### PR TITLE
[REVIEW] Update docs to remove references to master [skip ci]

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ into three categories:
 
 ### Your first issue
 
-1. Read the project's [README.md](https://github.com/rapidsai/clx/blob/master/README.md)
+1. Read the project's [README.md](https://github.com/rapidsai/clx/blob/main/README.md)
     to learn how to setup the development environment
 2. Find an issue to work on. The best way is to look for the [good first issue](https://github.com/rapidsai/clx/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
     or [help wanted](https://github.com/rapidsai/clx/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) labels

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # <div align="left"><img src="https://rapids.ai/assets/images/rapids_logo.png" width="90px"/>&nbsp;&nbsp;Cyber Log Accelerators (CLX)</div>
 
-**NOTE:** For the latest stable [README.md](https://github.com/rapidsai/clx/blob/master/README.md) ensure you are on the `master` branch.
+**NOTE:** For the latest stable [README.md](https://github.com/rapidsai/clx/blob/main/README.md) ensure you are on the `main` branch.
 
 CLX ("clicks") provides a collection of [RAPIDS](https://rapids.ai/) examples for security analysts, data scientists, and engineers to quickly get started applying RAPIDS and GPU acceleration to real-world cybersecurity use cases.
 
@@ -100,7 +100,7 @@ wf = netflow_workflow.NetflowWorkflow(source=source, destination=dest, name="my-
 wf.run_workflow()
 ```
 
-For additional examples, browse our complete [API documentation](https://docs.rapids.ai/api/clx/nightly/api.html), or check out our more detailed [notebooks](https://github.com/rapidsai/clx/tree/master/notebooks).
+For additional examples, browse our complete [API documentation](https://docs.rapids.ai/api/clx/nightly/api.html), or check out our more detailed [notebooks](https://github.com/rapidsai/clx/tree/main/notebooks).
 
 
 ## Getting CLX

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,4 +1,4 @@
-.. clx documentation master file, created by
+.. clx documentation main file, created by
    sphinx-quickstart on Thu Oct  3 16:57:19 2019.
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.

--- a/docs/source/intro-clx-dga.ipynb
+++ b/docs/source/intro-clx-dga.ipynb
@@ -26,7 +26,7 @@
     "\n",
     "Use CLX DGA Detection to build your own DGA Detection model that can then be used to predict whether a given domain is malicious or not. We will use a type of recurrent neural network called the Gated Recurrent Unit (GRU) for this example. The [CLX](https://github.com/rapidsai/clx) and [RAPIDS](https://rapids.ai/) libraries enable users train their models with up-to-date domain names representative of both benign and DGA generated strings. Using a [CLX workflow](./intro-clx-workflow.ipynb), this capability could also be used in production environments.  \n",
     "  \n",
-    "**For a more advanced, in-depth example of CLX DGA Detection view this Jupyter** [notebook](https://github.com/rapidsai/clx/blob/master/notebooks/dga_detection/DGA_Detection.ipynb)."
+    "**For a more advanced, in-depth example of CLX DGA Detection view this Jupyter** [notebook](https://github.com/rapidsai/clx/blob/main/notebooks/dga_detection/DGA_Detection.ipynb)."
    ]
   },
   {
@@ -154,7 +154,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Ideally, you will want to train your model over a number of `epochs` as detailed in our example DGA Detection [notebook](https://github.com/rapidsai/clx/blob/master/notebooks/dga_detection/DGA_Detection.ipynb)."
+    "Ideally, you will want to train your model over a number of `epochs` as detailed in our example DGA Detection [notebook](https://github.com/rapidsai/clx/blob/main/notebooks/dga_detection/DGA_Detection.ipynb)."
    ]
   },
   {

--- a/siem_integrations/README.md
+++ b/siem_integrations/README.md
@@ -1,6 +1,6 @@
 # <div align="left"><img src="https://rapids.ai/assets/images/rapids_logo.png" width="90px"/>&nbsp;CLX SIEM Integration</div>
 
-**NOTE:** For the latest stable [README.md](https://github.com/rapidsai/clx/blob/master/README.md) ensure you are on the `master` branch.
+**NOTE:** For the latest stable [README.md](https://github.com/rapidsai/clx/blob/main/README.md) ensure you are on the `main` branch.
 
 [RAPIDS](https://rapids.ai) CLX [SIEM](https://en.wikipedia.org/wiki/Security_information_and_event_management) Integrations provide features that enable interoperability between SIEMs and a RAPIDS/CLX environment. Currently, this support includes `splunk2kafka`, enabling data integration between Splunk and CLX.
 
@@ -15,15 +15,15 @@ Use this Splunk query template to send data to your Kafka instance.
 index="my-index" | export2kafka topic=my-topic broker=10.0.0.0:9092
 ```
 
-Additional query configuration options are detailed [here](https://github.com/rapidsai/clx/blob/master/splunk2kafka/export2kafka/README.md).
+Additional query configuration options are detailed [here](https://github.com/rapidsai/clx/blob/main/splunk2kafka/export2kafka/README.md).
 
 ### Install Splunk2Kafka
 
 Install the following applications into your Splunk instance by following the instructions linked below. 
 In order to utilize splunk2kafka, a [running Kafka instance](https://kafka.apache.org/quickstart) is required.
 
-1. Install splunk_wrapper ([Instructions](https://github.com/rapidsai/clx/blob/master/splunk2kafka/splunk_wrapper/README.md))
-2. Install export2kafka ([Instructions](https://github.com/rapidsai/clx-siem-integration/blob/master/splunk2kafka/export2kafka/README.md))
+1. Install splunk_wrapper ([Instructions](https://github.com/rapidsai/clx/blob/main/splunk2kafka/splunk_wrapper/README.md))
+2. Install export2kafka ([Instructions](https://github.com/rapidsai/clx-siem-integration/blob/main/splunk2kafka/export2kafka/README.md))
 
 
 ## CLX Query
@@ -117,4 +117,4 @@ Download MovieLens stable benchmark [dataset](https://grouplens.org/datasets/mov
 
 ## Contributing Guide
 
-Review the [CONTRIBUTING.md](https://github.com/rapidsai/clx/blob/master/CONTRIBUTING.md) file for information on how to contribute code and issues to the project.
+Review the [CONTRIBUTING.md](https://github.com/rapidsai/clx/blob/main/CONTRIBUTING.md) file for information on how to contribute code and issues to the project.


### PR DESCRIPTION
This PR removes unecessary references to master or updates references to the new main branch in CI scripts and other OPS-owned files.