### PR TITLE
Pin seqeval to 0.0.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - PR #236 Fix RAPIDS logo in READMEs
 - PR #240 Fix errors from upstream changes to cuDF DataFrame.drop and RMM
 - PR #241 Fix unit tests after cuDF update
+- PR #242 Pin seqeval to v0.0.12 for cybert example training notebook
 
 # clx 0.15.0 (26 Aug 2020)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apt update -y --fix-missing && \
     apt upgrade -y
 
 RUN source activate rapids && \
-    conda install -c pytorch "pytorch>=1.5" torchvision "scikit-learn>=0.21" ipywidgets python-confluent-kafka transformers seqeval python-whois seaborn requests matplotlib pytest jupyterlab && \
+    conda install -c pytorch "pytorch>=1.5" torchvision "scikit-learn>=0.21" ipywidgets python-confluent-kafka transformers "seqeval=0.0.12" python-whois seaborn requests matplotlib pytest jupyterlab && \
     pip install "git+https://github.com/rapidsai/cudatashader.git" && \
     pip install mockito && \
     pip install wget

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -53,7 +53,7 @@ conda install -c pytorch -c gwerbin \
     "torchvision" \
     "python-confluent-kafka" \
     "transformers" \
-    "seqeval" \
+    "seqeval=0.0.12" \
     "python-whois" \
     "requests" \
     "matplotlib" \


### PR DESCRIPTION
Pin seqeval to v0.0.12. Recently released v0.0.17 breaks `cybert_example_training` notebook.