### PR TITLE
Fix error handling for ci/gpu/build.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - PR #240 Fix errors from upstream changes to cuDF DataFrame.drop and RMM
 - PR #241 Fix unit tests after cuDF update
 - PR #242 Pin seqeval to v0.0.12 for cybert example training notebook
+- PR #243 Fix error handling in `ci/gpu/build.sh`
 
 # clx 0.15.0 (26 Aug 2020)
 

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -34,7 +34,7 @@ logger "Get env..."
 env
 
 logger "Activate conda env..."
-source activate gdf
+source activate rapids
 
 logger "Check versions..."
 python --version
@@ -78,6 +78,9 @@ $WORKSPACE/build.sh clean libclx clx
 ################################################################################
 # TEST - Test python package
 ################################################################################
+set +e -Eo pipefail
+EXITCODE=0
+trap "EXITCODE=1" ERR
 
 if hasArg --skip-tests; then
     logger "Skipping Tests..."
@@ -87,3 +90,5 @@ else
     ${WORKSPACE}/ci/gpu/test-notebooks.sh 2>&1 | tee nbtest.log
     python ${WORKSPACE}/ci/utils/nbtestlog2junitxml.py nbtest.log
 fi
+
+exit "${EXITCODE}"

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -43,7 +43,7 @@ python --version
 conda config --set ssl_verify False
 
 logger "conda install required packages"
-conda install -c pytorch -c gwerbin \
+conda install -y -c pytorch -c gwerbin \
     "rapids-build-env=$MINOR_VERSION.*" \
     "rapids-notebook-env=$MINOR_VERSION.*" \
     "cugraph=${MINOR_VERSION}" \

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -91,4 +91,4 @@ else
     python ${WORKSPACE}/ci/utils/nbtestlog2junitxml.py nbtest.log
 fi
 
-exit "${EXITCODE}"
+return "${EXITCODE}"


### PR DESCRIPTION
This PR fixes error handling for `ci/gpu/build.sh`. Previously, the script was not returning the correct error code when notebook tests failed.

For reference, the `set` flags and `trap` were taken from https://citizen428.net/blog/bash-error-handling-with-trap/

This PR adds a `return` instead of an `exit` to `ci/gpu/build.sh` since `ci/gpu/build.sh` is `source`ed from the Jenkins job:

![image](https://user-images.githubusercontent.com/7400326/94861584-c3210200-0405-11eb-8755-5ea9ebbf159e.png)
