### PR TITLE
[REVIEW] Allow CuPy 8.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - PR #237 Cybert streamz memory optimization
 - PR #238 Deprecate CLX subword tokenizer
 - PR #244 Add cybert dataloader
+- PR #247 Allow CuPy 8.x
 
 ## Bug Fixes
 - PR #231 Fix segmentation fault in cybert notebook

--- a/conda/environments/clx_dev_cuda10.1.yml
+++ b/conda/environments/clx_dev_cuda10.1.yml
@@ -14,7 +14,7 @@ dependencies:
 - cuml=0.16.*
 - cuxfilter=0.16.*
 - dask-cudf=0.16.*
-- cupy>=6.6.0,<8.0.0a0,!=7.1.0
+- cupy>7.1.0,<9.0.0a0
 - cmake>=3.12
 - cmake_setuptools>=0.1.3
 - cython>=0.29,<0.30

--- a/conda/environments/clx_dev_cuda10.2.yml
+++ b/conda/environments/clx_dev_cuda10.2.yml
@@ -14,7 +14,7 @@ dependencies:
 - cuml=0.16.*
 - cuxfilter=0.16.*
 - dask-cudf=0.16.*
-- cupy>=6.6.0,<8.0.0a0,!=7.1.0
+- cupy>7.1.0,<9.0.0a0
 - cmake>=3.12
 - cmake_setuptools>=0.1.3
 - cython>=0.29,<0.30


### PR DESCRIPTION
Both cuML and cuSignal would like to move to cuPy 8 and have done initial testing with it. This change does not eliminate 7.x support, just allows 8.x.﻿

PR for cuml: rapidsai/cuml#2910
PR for integration: rapidsai/integration#139
PR for cudf: https://github.com/rapidsai/cudf/pull/6409