### PR TITLE
[gpuCI] Auto-merge branch-0.16 to branch-0.17 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - PR #241 Fix unit tests after cuDF update
 - PR #242 Pin seqeval to v0.0.12 for cybert example training notebook
 - PR #243 Fix error handling in `ci/gpu/build.sh`
+- PR #256 Fix missing projects variable from docs build
 
 # clx 0.15.0 (26 Aug 2020)
 

--- a/ci/docs/build.sh
+++ b/ci/docs/build.sh
@@ -17,6 +17,7 @@ export NIGHTLY_VERSION=${NIGHTLY_OVERRIDE:=$(echo $BRANCH_VERSION | awk -F. '{ p
 export CUDA_REL=${CUDA_VERSION%.*}
 export CUDA_SHORT=${CUDA_REL//./}
 export CLX_HOME=$WORKSPACE/clx_build
+export PROJECTS=(clx)
 
 # Switch to project root; also root of repo checkout
 cd $WORKSPACE
@@ -44,7 +45,6 @@ $CXX --version
 conda list
 
 #clx source build
-git clone --single-branch --branch branch-${BRANCH_VERSION} https://github.com/rapidsai/clx.git ${CLX_HOME}
 ${CLX_HOME}/build.sh clean libclx clx
 
 #clx Sphinx Build


### PR DESCRIPTION
Auto-merge triggered by push to `branch-0.16` that creates a PR to keep `branch-0.17` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.