### PR TITLE
[REVIEW] FIX Fix incorrect workspace variable [skip-ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - PR #242 Pin seqeval to v0.0.12 for cybert example training notebook
 - PR #243 Fix error handling in `ci/gpu/build.sh`
 - PR #256 Fix missing projects variable from docs build
+- PR #261 Fix incorrect workspace variable in docs build
 
 # clx 0.15.0 (26 Aug 2020)
 

--- a/ci/docs/build.sh
+++ b/ci/docs/build.sh
@@ -16,11 +16,10 @@ export DOCS_WORKSPACE=$WORKSPACE/docs
 export NIGHTLY_VERSION=${NIGHTLY_OVERRIDE:=$(echo $BRANCH_VERSION | awk -F. '{ print $2 }')}
 export CUDA_REL=${CUDA_VERSION%.*}
 export CUDA_SHORT=${CUDA_REL//./}
-export CLX_HOME=$WORKSPACE/clx_build
 export PROJECTS=(clx)
 
 # Switch to project root; also root of repo checkout
-cd $WORKSPACE
+cd $PROJECT_WORKSPACE
 export GIT_DESCRIBE_TAG=`git describe --tags`
 export MINOR_VERSION=`echo $GIT_DESCRIBE_TAG | grep -o -E '([0-9]+\.[0-9]+)'`
 
@@ -45,11 +44,11 @@ $CXX --version
 conda list
 
 #clx source build
-${CLX_HOME}/build.sh clean libclx clx
+${PROJECT_WORKSPACE}/build.sh clean libclx clx
 
 #clx Sphinx Build
 logger "Build clx docs..."
-cd $CLX_HOME/docs
+cd ${PROJECT_WORKSPACE}/docs
 make html
 
 cd $DOCS_WORKSPACE
@@ -59,6 +58,6 @@ if [ ! -d "api/clx/$BRANCH_VERSION" ]; then
 fi
 
 rm -rf api/clx/$BRANCH_VERSION/*
-mv $CLX_HOME/docs/build/html/* $DOCS_WORKSPACE/api/clx/$BRANCH_VERSION
+mv ${PROJECT_WORKSPACE}/docs/build/html/* $DOCS_WORKSPACE/api/clx/$BRANCH_VERSION
 
 


### PR DESCRIPTION
Fixes an unused variable in our Jenkins build. `PROJECT_WORKSPACE` is defined in the jenkins job as `/rapids/${REPO_NAME}` which is where clx is cloned to in the job.

<img width="607" alt="Screen Shot 2020-10-15 at 2 33 12 PM" src="https://user-images.githubusercontent.com/18494947/96171809-78b67f80-0ef3-11eb-9c3f-1efe254ffdd1.png">