### PR TITLE
Switch Ports & Fix CLX Container Runtime

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,11 +2,12 @@ version: '3'
 services:
   #JupyterLab will be available at port 9888
   clx:
+    runtime: nvidia
     build: .
     ports:
       - "9888:8888"
-      - "8787:8787"
-      - "8686:8686"
+      - "9787:8787"
+      - "9686:8686"
     stdin_open: true
     tty: true
   #Zookeeper will be available at `zookeeper:2181`


### PR DESCRIPTION
# Summary of Changes
* Switch ports `8787` to `9787` and ports `8686` to `9686` to avoid overlap.
* Add `runtime: nvidia` to service `clx`. `docker-compose up` will fail without this.