### PR TITLE
[REVIEW] Docs build script fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - PR #269 Add cybert class to docs build
 - PR #271 Alert Analysis notebook fix
 - PR #294 API doc fixes
+- PR #295 Docs build script fix
 
 # clx 0.16.0 (21 Oct 2020)
 

--- a/ci/docs/build.sh
+++ b/ci/docs/build.sh
@@ -32,7 +32,7 @@ nvidia-smi
 logger "Activate conda env..."
 source activate rapids
 conda install --freeze-installed -c rapidsai-nightly -c rapidsai -c nvidia -c pytorch -c conda-forge \
-    pytorch torchvision requests yaml python-confluent-kafka python-whois markdown beautifulsoup4 jq
+    "pytorch>=1.7" torchvision transformers requests yaml python-confluent-kafka python-whois markdown beautifulsoup4 jq
     
 pip install mockito
 pip install cupy-cuda${CUDA_SHORT}


### PR DESCRIPTION
Some API docs were not being generated because of old/missing dependencies.
- Added `transformers`
- Updated `pytorch` to current version