### PR TITLE
Auto-label PRs based on their content [skip-ci]

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -3,23 +3,23 @@
 # Labels culled from https://github.com/rapidsai/clx/labels
 
 Python:
-  - python/
-  - notebooks/
+  - python/**
+  - notebooks/**
   
 libclx:
-  - cpp/
+  - cpp/**
 
 CMake:
   - **/CMakeLists.txt
-  - **/cmake/
+  - **/cmake/**
   
 Java:
-  - java/
+  - java/**
   
 Ops:
-  - .github/
-  - /ci/
-  - conda/
+  - .github/**
+  - /ci/**
+  - conda/**
   - **/Dockerfile
   - **/.dockerignore
-  - docker/
+  - docker/**

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -5,21 +5,9 @@
 Python:
   - 'python/**'
   - 'notebooks/**'
-  
-libclx:
-  - 'cpp/**'
 
-CMake:
-  - '**/CMakeLists.txt'
-  - '**/cmake/**'
-  
-Java:
-  - 'java/**'
-  
-Ops:
-  - '.github/**'
+ci:
   - 'ci/**'
+
+conda:
   - 'conda/**'
-  - '**/Dockerfile'
-  - '**/.dockerignore'
-  - 'docker/**'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -5,6 +5,9 @@
 Python:
   - 'python/**'
   - 'notebooks/**'
+  
+integration:
+  - 'siem_integrations'
 
 gpuCI:
   - 'ci/**'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,25 +1,25 @@
 # https://github.com/actions/labeler#common-examples
-# Adapted from https://github.com/rapidsai/cudf/blob/main/.github/CODEOWNERS
+# Adapted from https://github.com/rapidsai/clx/blob/main/.github/CODEOWNERS
 # Labels culled from https://github.com/rapidsai/clx/labels
 
 Python:
-  - python/**
-  - notebooks/**
+  - 'python/**'
+  - 'notebooks/**'
   
 libclx:
-  - cpp/**
+  - 'cpp/**'
 
 CMake:
-  - **/CMakeLists.txt
-  - **/cmake/**
+  - '**/CMakeLists.txt'
+  - '**/cmake/**'
   
 Java:
-  - java/**
+  - 'java/**'
   
 Ops:
-  - .github/**
-  - /ci/**
-  - conda/**
-  - **/Dockerfile
-  - **/.dockerignore
-  - docker/**
+  - '.github/**'
+  - 'ci/**'
+  - 'conda/**'
+  - '**/Dockerfile'
+  - '**/.dockerignore'
+  - 'docker/**'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -6,7 +6,7 @@ Python:
   - 'python/**'
   - 'notebooks/**'
 
-ci:
+gpuCI:
   - 'ci/**'
 
 conda:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,25 @@
+# https://github.com/actions/labeler#common-examples
+# Adapted from https://github.com/rapidsai/cudf/blob/main/.github/CODEOWNERS
+# Labels culled from https://github.com/rapidsai/clx/labels
+
+Python:
+  - python/
+  - notebooks/
+  
+libclx:
+  - cpp/
+
+CMake:
+  - **/CMakeLists.txt
+  - **/cmake/
+  
+Java:
+  - java/
+  
+Ops:
+  - .github/
+  - /ci/
+  - conda/
+  - **/Dockerfile
+  - **/.dockerignore
+  - docker/

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,11 @@
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@main
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
This PR adds the GitHub action [PR Labeler](https://github.com/actions/labeler) to auto-label PRs based on their content. 

Labeling is managed with a configuration file `.github/labeler.yml` using the following [options](https://github.com/actions/labeler#usage).
