### PR TITLE
[REVIEW] Pin to PyTorch 1.7.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN apt update -y --fix-missing && \
     apt install -y krb5-user
 
 RUN source activate rapids && \
-    conda install -c pytorch "pytorch>=1.7" torchvision "cudf_kafka=${RAPIDS_VERSION}" "custreamz=${RAPIDS_VERSION}" "scikit-learn>=0.21" "nodejs>=12" ipywidgets python-confluent-kafka "transformers=3.5.*" "seqeval=0.0.12" python-whois seaborn requests matplotlib pytest jupyterlab && \
+    conda install -c pytorch "pytorch=1.7.0" torchvision "cudf_kafka=${RAPIDS_VERSION}" "custreamz=${RAPIDS_VERSION}" "scikit-learn>=0.21" "nodejs>=12" ipywidgets python-confluent-kafka "transformers=3.5.*" "seqeval=0.0.12" python-whois seaborn requests matplotlib pytest jupyterlab && \
     pip install "git+https://github.com/rapidsai/cudatashader.git" && \
     pip install mockito && \
     pip install wget

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -49,7 +49,7 @@ conda install -y -c pytorch -c gwerbin \
     "cugraph=${MINOR_VERSION}" \
     "cuml=${MINOR_VERSION}" \
     "dask-cuda=${MINOR_VERSION}" \
-    "pytorch>=1.7" \
+    "pytorch=1.7.0" \
     "torchvision" \
     "python-confluent-kafka" \
     "transformers=3.5.*" \

--- a/conda/environments/clx_dev_cuda10.1.yml
+++ b/conda/environments/clx_dev_cuda10.1.yml
@@ -16,7 +16,7 @@ dependencies:
 - dask-cudf=0.18.*
 - cupy>7.1.0,<9.0.0a0
 - cudatoolkit=10.1
-- pytorch>=1.7
+- pytorch=1.7.0
 - torchvision
 - scikit-learn>=0.21
 - s3fs

--- a/conda/environments/clx_dev_cuda10.2.yml
+++ b/conda/environments/clx_dev_cuda10.2.yml
@@ -16,7 +16,7 @@ dependencies:
 - dask-cudf=0.18.*
 - cupy>7.1.0,<9.0.0a0
 - cudatoolkit=10.2
-- pytorch>=1.7
+- pytorch=1.7.0
 - torchvision
 - scikit-learn>=0.21
 - s3fs

--- a/conda/environments/clx_dev_cuda11.0.yml
+++ b/conda/environments/clx_dev_cuda11.0.yml
@@ -16,7 +16,7 @@ dependencies:
 - dask-cudf=0.18.*
 - cupy>7.1.0,<9.0.0a0
 - cudatoolkit=11.0
-- pytorch>=1.7
+- pytorch=1.7.0
 - torchvision
 - scikit-learn>=0.21
 - s3fs

--- a/conda/recipes/clx/meta.yaml
+++ b/conda/recipes/clx/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     - scikit-learn>=0.21
     - cugraph {{ minor_version }}.*
     - cuml {{ minor_version }}.*
-    - pytorch>=1.7
+    - pytorch=1.7.0
     - torchvision
     - transformers 3.5.*
 

--- a/examples/streamz/Dockerfile
+++ b/examples/streamz/Dockerfile
@@ -63,7 +63,7 @@ EXPOSE 2181
 EXPOSE 9092
 
 RUN source activate rapids && \
-    conda install -c pytorch "pytorch>=1.7" torchvision "cudf_kafka=${RAPIDS_VERSION}" "custreamz=${RAPIDS_VERSION}" "scikit-learn>=0.21" "nodejs>=12" ipywidgets python-confluent-kafka "transformers=3.5.*" "seqeval=0.0.12" python-whois seaborn requests matplotlib pytest jupyterlab "openjdk=8.0.152" dask-cuda && \
+    conda install -c pytorch "pytorch=1.7.0" torchvision "cudf_kafka=${RAPIDS_VERSION}" "custreamz=${RAPIDS_VERSION}" "scikit-learn>=0.21" "nodejs>=12" ipywidgets python-confluent-kafka "transformers=3.5.*" "seqeval=0.0.12" python-whois seaborn requests matplotlib pytest jupyterlab "openjdk=8.0.152" dask-cuda && \
     pip install "git+https://github.com/rapidsai/cudatashader.git" && \
     pip install mockito && \
     pip install wget && \


### PR DESCRIPTION
`pytorch>=1.7` causes CPU version of v1.7.1 to be installed. This PR updates gpuci build scripts, conda recipes, conda environment yaml's and Dockerfiles to pin to v1.7.0.

Closes #319.

Also updated CLX PyTorch version in `/rapidsai/docker` PR:
https://github.com/rapidsai/docker/pull/240