### PR TITLE
[REVIEW] Fix pytorch version in conda recipe

### DIFF
--- a/conda/recipes/clx/meta.yaml
+++ b/conda/recipes/clx/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     - scikit-learn>=0.21
     - cugraph {{ minor_version }}.*
     - cuml {{ minor_version }}.*
-    - pytorch=1.7.0
+    - pytorch 1.7.0
     - torchvision
     - transformers 3.5.*
 


### PR DESCRIPTION
Used wrong syntax to pin pytorch version to v1.7.0 in conda recipe. The conda package was defaulting to v1.7.1 which, for some reason, installs the cpu version (#319). This PR corrects the syntax.