### PR TITLE
[REVIEW] Port heuristic update

### DIFF
--- a/python/clx/heuristics/ports.py
+++ b/python/clx/heuristics/ports.py
@@ -113,6 +113,6 @@ def major_ports(addr_col, port_col, min_conns=1, eph_min=10000):
 
     gdf.loc[gdf["port"] >= eph_min, "service"] = "ephemeral"
 
-    gdf = gdf.groupby(["addr", "port", "service"], dropna=False, as_index=False).sum()
+    gdf = gdf.groupby(["addr", "port", "service"], dropna=False, as_index=False, sort=True).sum()
 
     return gdf

--- a/python/clx/heuristics/ports.py
+++ b/python/clx/heuristics/ports.py
@@ -111,13 +111,7 @@ def major_ports(addr_col, port_col, min_conns=1, eph_min=10000):
     # Add IANA service names to node lists
     gdf = gdf.merge(iana_lookup_df, on=['port'], how='left')
 
-    # The following column update is blocked by https://github.com/rapidsai/cudf/issues/3186
-    # Doing workaround until fix.
-    # gdf.loc[gdf["port"] >= eph_min, "service"] = "ephemeral"
-    eph_gdf = gdf[gdf["port"] >= eph_min]
-    if not eph_gdf.empty:
-        eph_gdf["service"] = "ephemeral"
-        gdf = cudf.concat([gdf[gdf["port"] < eph_min], eph_gdf])
+    gdf.loc[gdf["port"] >= eph_min, "service"] = "ephemeral"
 
     gdf = gdf.groupby(["addr", "port", "service"], dropna=False, as_index=False).sum()
 

--- a/python/clx/tests/test_port_heuristic.py
+++ b/python/clx/tests/test_port_heuristic.py
@@ -27,6 +27,7 @@ def test_major_ports():
     expected["conns"] = [2, 1, 1]
 
     actual = ports.major_ports(input_addr_col, input_port_col)
+    actual = actual.sort_values("addr").reset_index(drop=True)
 
     assert actual.equals(expected)
 
@@ -42,6 +43,7 @@ def test_major_ports_ephemeral():
     expected["conns"] = [1, 1, 1, 1]
 
     actual = ports.major_ports(input_addr_col, input_port_col, eph_min=50000)
+    actual = actual.sort_values("addr").reset_index(drop=True)
 
     assert actual.equals(expected)
 
@@ -57,6 +59,7 @@ def test_major_ports_min_conns():
     expected["conns"] = [2]
 
     actual = ports.major_ports(input_addr_col, input_port_col, min_conns=2)
+    actual = actual.sort_values("addr").reset_index(drop=True)
 
     assert actual.equals(expected)
 
@@ -72,5 +75,6 @@ def test_major_ports_all_params():
     expected["conns"] = [2, 2]
 
     actual = ports.major_ports(input_addr_col, input_port_col, min_conns=2, eph_min=7000)
+    actual = actual.sort_values("addr").reset_index(drop=True)
 
     assert actual.equals(expected)

--- a/python/clx/tests/test_port_heuristic.py
+++ b/python/clx/tests/test_port_heuristic.py
@@ -27,7 +27,6 @@ def test_major_ports():
     expected["conns"] = [2, 1, 1]
 
     actual = ports.major_ports(input_addr_col, input_port_col)
-    actual = actual.sort_values("addr").reset_index(drop=True)
 
     assert actual.equals(expected)
 
@@ -43,7 +42,6 @@ def test_major_ports_ephemeral():
     expected["conns"] = [1, 1, 1, 1]
 
     actual = ports.major_ports(input_addr_col, input_port_col, eph_min=50000)
-    actual = actual.sort_values("addr").reset_index(drop=True)
 
     assert actual.equals(expected)
 
@@ -59,7 +57,6 @@ def test_major_ports_min_conns():
     expected["conns"] = [2]
 
     actual = ports.major_ports(input_addr_col, input_port_col, min_conns=2)
-    actual = actual.sort_values("addr").reset_index(drop=True)
 
     assert actual.equals(expected)
 
@@ -75,6 +72,5 @@ def test_major_ports_all_params():
     expected["conns"] = [2, 2]
 
     actual = ports.major_ports(input_addr_col, input_port_col, min_conns=2, eph_min=7000)
-    actual = actual.sort_values("addr").reset_index(drop=True)
 
     assert actual.equals(expected)


### PR DESCRIPTION
- Upstream changes to cuDF changed order of port heuristic results. Updated `groupby` in heuristic to sort results.
- Removed workaround from port heuristic code now that cuDF `loc` issue is fixed.