### PR TITLE
[gpuCI] Auto-merge branch-0.18 to branch-0.19 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,6 @@
-# clx 0.18.0 (Date TBD)
+# 0.18.0
 
-## New Features
-- PR #328 SlashNext API integration
-
-## Improvements
-- PR #276 Project Flash and gpuCI Scripts Update
-- PR #303 CLX sequence classifier
-- PR #308 CLX streamz workflow updates
-- PR #313 XGBoost training notebook
-
-## Bug Fixes
-- PR #315 Fix detector dataset errors when batchsize set to small
+Please see https://github.com/rapidsai/clx/releases/tag/branch-0.18-latest for the latest changes to this development branch.
 
 # clx 0.17.0 (10 Dec 2020)
 


### PR DESCRIPTION
Auto-merge triggered by push to `branch-0.18` that creates a PR to keep `branch-0.19` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.