### PR TITLE
[REVIEW] Update to PyTorch 1.7.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN apt update -y --fix-missing && \
     apt install -y krb5-user
 
 RUN source activate rapids && \
-    conda install -c pytorch "pytorch=1.7.0" torchvision "cudf_kafka=${RAPIDS_VERSION}" "custreamz=${RAPIDS_VERSION}" "scikit-learn>=0.21" "nodejs>=12" ipywidgets python-confluent-kafka "transformers=4.*" "seqeval=0.0.12" python-whois seaborn requests matplotlib pytest jupyterlab && \
+    conda install -c pytorch "pytorch=1.7.*" torchvision "cudf_kafka=${RAPIDS_VERSION}" "custreamz=${RAPIDS_VERSION}" "scikit-learn>=0.21" "nodejs>=12" ipywidgets python-confluent-kafka "transformers=4.*" "seqeval=0.0.12" python-whois seaborn requests matplotlib pytest jupyterlab && \
     pip install "git+https://github.com/rapidsai/cudatashader.git" && \
     pip install mockito && \
     pip install wget && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 # An integration test & dev container which builds and installs CLX from default branch
 ARG RAPIDS_VERSION=0.18
-ARG CUDA_VERSION=11.0
+ARG CUDA_VERSION=10.1
 ARG CUDA_SHORT_VERSION=${CUDA_VERSION}
 ARG LINUX_VERSION=ubuntu18.04
-ARG PYTHON_VERSION=3.8
+ARG PYTHON_VERSION=3.7
 FROM rapidsai/rapidsai-dev-nightly:${RAPIDS_VERSION}-cuda${CUDA_VERSION}-devel-${LINUX_VERSION}-py${PYTHON_VERSION}
 
 # Add everything from the local build context

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 # An integration test & dev container which builds and installs CLX from default branch
 ARG RAPIDS_VERSION=0.18
-ARG CUDA_VERSION=10.1
+ARG CUDA_VERSION=11.0
 ARG CUDA_SHORT_VERSION=${CUDA_VERSION}
 ARG LINUX_VERSION=ubuntu18.04
-ARG PYTHON_VERSION=3.7
+ARG PYTHON_VERSION=3.8
 FROM rapidsai/rapidsai-dev-nightly:${RAPIDS_VERSION}-cuda${CUDA_VERSION}-devel-${LINUX_VERSION}-py${PYTHON_VERSION}
 
 # Add everything from the local build context
@@ -15,7 +15,7 @@ RUN apt update -y --fix-missing && \
     apt install -y krb5-user
 
 RUN source activate rapids && \
-    conda install -c pytorch "pytorch=1.7.*" torchvision "cudf_kafka=${RAPIDS_VERSION}" "custreamz=${RAPIDS_VERSION}" "scikit-learn>=0.21" "nodejs>=12" ipywidgets python-confluent-kafka "transformers=4.*" "seqeval=0.0.12" python-whois seaborn requests matplotlib pytest jupyterlab && \
+    conda install -c pytorch "pytorch=1.7.1" torchvision "cudf_kafka=${RAPIDS_VERSION}" "custreamz=${RAPIDS_VERSION}" "scikit-learn>=0.21" "nodejs>=12" ipywidgets python-confluent-kafka "transformers=4.*" "seqeval=0.0.12" python-whois seaborn requests matplotlib pytest jupyterlab && \
     pip install "git+https://github.com/rapidsai/cudatashader.git" && \
     pip install mockito && \
     pip install wget && \

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -46,7 +46,7 @@ gpuci_conda_retry install -y -c pytorch -c gwerbin \
     "cuml=${MINOR_VERSION}" \
     "dask-cuda=${MINOR_VERSION}" \
     "cuxfilter=${MINOR_VERSION}" \
-    "pytorch=1.7.0" \
+    "pytorch=1.7.*" \
     "torchvision" \
     "python-confluent-kafka" \
     "transformers=4.*" \

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -46,7 +46,7 @@ gpuci_conda_retry install -y -c pytorch -c gwerbin \
     "cuml=${MINOR_VERSION}" \
     "dask-cuda=${MINOR_VERSION}" \
     "cuxfilter=${MINOR_VERSION}" \
-    "pytorch=1.7.*" \
+    "pytorch=1.7.1" \
     "torchvision" \
     "python-confluent-kafka" \
     "transformers=4.*" \

--- a/conda/environments/clx_dev_cuda10.1.yml
+++ b/conda/environments/clx_dev_cuda10.1.yml
@@ -16,7 +16,7 @@ dependencies:
 - dask-cudf=0.18.*
 - cupy>7.1.0,<9.0.0a0
 - cudatoolkit=10.1
-- pytorch=1.7.*
+- pytorch=1.7.1
 - torchvision
 - scikit-learn>=0.21
 - s3fs

--- a/conda/environments/clx_dev_cuda10.1.yml
+++ b/conda/environments/clx_dev_cuda10.1.yml
@@ -16,7 +16,7 @@ dependencies:
 - dask-cudf=0.18.*
 - cupy>7.1.0,<9.0.0a0
 - cudatoolkit=10.1
-- pytorch=1.7.0
+- pytorch=1.7.*
 - torchvision
 - scikit-learn>=0.21
 - s3fs

--- a/conda/environments/clx_dev_cuda10.2.yml
+++ b/conda/environments/clx_dev_cuda10.2.yml
@@ -16,7 +16,7 @@ dependencies:
 - dask-cudf=0.18.*
 - cupy>7.1.0,<9.0.0a0
 - cudatoolkit=10.2
-- pytorch=1.7.*
+- pytorch=1.7.1
 - torchvision
 - scikit-learn>=0.21
 - s3fs

--- a/conda/environments/clx_dev_cuda10.2.yml
+++ b/conda/environments/clx_dev_cuda10.2.yml
@@ -16,7 +16,7 @@ dependencies:
 - dask-cudf=0.18.*
 - cupy>7.1.0,<9.0.0a0
 - cudatoolkit=10.2
-- pytorch=1.7.0
+- pytorch=1.7.*
 - torchvision
 - scikit-learn>=0.21
 - s3fs

--- a/conda/environments/clx_dev_cuda11.0.yml
+++ b/conda/environments/clx_dev_cuda11.0.yml
@@ -16,7 +16,7 @@ dependencies:
 - dask-cudf=0.18.*
 - cupy>7.1.0,<9.0.0a0
 - cudatoolkit=11.0
-- pytorch=1.7.0
+- pytorch=1.7.*
 - torchvision
 - scikit-learn>=0.21
 - s3fs

--- a/conda/environments/clx_dev_cuda11.0.yml
+++ b/conda/environments/clx_dev_cuda11.0.yml
@@ -16,7 +16,7 @@ dependencies:
 - dask-cudf=0.18.*
 - cupy>7.1.0,<9.0.0a0
 - cudatoolkit=11.0
-- pytorch=1.7.*
+- pytorch=1.7.1
 - torchvision
 - scikit-learn>=0.21
 - s3fs

--- a/conda/recipes/clx/meta.yaml
+++ b/conda/recipes/clx/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     - scikit-learn>=0.21
     - cugraph {{ minor_version }}.*
     - cuml {{ minor_version }}.*
-    - pytorch 1.7.0
+    - pytorch 1.7.*
     - torchvision
     - transformers 4.*
 

--- a/conda/recipes/clx/meta.yaml
+++ b/conda/recipes/clx/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     - scikit-learn>=0.21
     - cugraph {{ minor_version }}.*
     - cuml {{ minor_version }}.*
-    - pytorch 1.7.*
+    - pytorch 1.7.1
     - torchvision
     - transformers 4.*
 

--- a/examples/streamz/Dockerfile
+++ b/examples/streamz/Dockerfile
@@ -63,7 +63,7 @@ EXPOSE 2181
 EXPOSE 9092
 
 RUN source activate rapids && \
-    conda install -c pytorch "pytorch=1.7.0" torchvision "cudf_kafka=${RAPIDS_VERSION}" "custreamz=${RAPIDS_VERSION}" "scikit-learn>=0.21" "nodejs>=12" ipywidgets python-confluent-kafka "transformers=4.*" "seqeval=0.0.12" python-whois seaborn requests matplotlib pytest jupyterlab "openjdk=8.0.152" dask-cuda && \
+    conda install -c pytorch "pytorch=1.7.*" torchvision "cudf_kafka=${RAPIDS_VERSION}" "custreamz=${RAPIDS_VERSION}" "scikit-learn>=0.21" "nodejs>=12" ipywidgets python-confluent-kafka "transformers=4.*" "seqeval=0.0.12" python-whois seaborn requests matplotlib pytest jupyterlab "openjdk=8.0.152" dask-cuda && \
     pip install "git+https://github.com/rapidsai/cudatashader.git" && \
     pip install mockito && \
     pip install wget && \

--- a/examples/streamz/Dockerfile
+++ b/examples/streamz/Dockerfile
@@ -63,7 +63,7 @@ EXPOSE 2181
 EXPOSE 9092
 
 RUN source activate rapids && \
-    conda install -c pytorch "pytorch=1.7.*" torchvision "cudf_kafka=${RAPIDS_VERSION}" "custreamz=${RAPIDS_VERSION}" "scikit-learn>=0.21" "nodejs>=12" ipywidgets python-confluent-kafka "transformers=4.*" "seqeval=0.0.12" python-whois seaborn requests matplotlib pytest jupyterlab "openjdk=8.0.152" dask-cuda && \
+    conda install -c pytorch "pytorch=1.7.1" torchvision "cudf_kafka=${RAPIDS_VERSION}" "custreamz=${RAPIDS_VERSION}" "scikit-learn>=0.21" "nodejs>=12" ipywidgets python-confluent-kafka "transformers=4.*" "seqeval=0.0.12" python-whois seaborn requests matplotlib pytest jupyterlab "openjdk=8.0.152" dask-cuda && \
     pip install "git+https://github.com/rapidsai/cudatashader.git" && \
     pip install mockito && \
     pip install wget && \


### PR DESCRIPTION
The conda install of PyTorch v1.7.1 on the `rapidsai` Docker images was previously installing the cpu package. We therefore pinned to version v1.7.0. The conflicts in the `rapidsai` images have apparently been resolved so we're now updating to v1.7.1.

- Update to latest stable PyTorch (v1.7.1)
- Update gpu build script
- Update conda recipe
- Update conda environment yaml's
- Update Dockerfiles