### PR TITLE
[REVIEW] Update Network Mapping notebook to skip Louvain on Pascal

### DIFF
--- a/notebooks/network_mapping/Network_Mapping_With_RAPIDS_And_CLX.ipynb
+++ b/notebooks/network_mapping/Network_Mapping_With_RAPIDS_And_CLX.ipynb
@@ -307,7 +307,15 @@
    "cell_type": "code",
    "execution_count": 14,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-0.031225887345679007\n"
+     ]
+    }
+   ],
    "source": [
     "# only run lovain if running on newer than Pascal architecture\n",
     "if not is_device_version_less_than((7, 0)):\n",
@@ -321,7 +329,7 @@
     "    nodes_cg_gdf = nodes_cg_gdf.merge(lv_gdf, on=['idx'], how='left')\n",
     "    nodes_cg_gdf = nodes_cg_gdf.drop(['vertex'], axis=1)\n",
     "\n",
-    "    lv_mod # Louvain modularity score"
+    "    print(lv_mod) # Louvain modularity score"
    ]
   },
   {

--- a/notebooks/network_mapping/Network_Mapping_With_RAPIDS_And_CLX.ipynb
+++ b/notebooks/network_mapping/Network_Mapping_With_RAPIDS_And_CLX.ipynb
@@ -41,6 +41,7 @@
    "source": [
     "import cudf\n",
     "import cugraph\n",
+    "from cugraph.utilities.utils import is_device_version_less_than\n",
     "\n",
     "from clx.heuristics import ports\n",
     "import clx.parsers.zeek as zeek\n",
@@ -308,42 +309,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Build new graph with edge values required for Louvain\n",
-    "G = cugraph.Graph()\n",
-    "G.from_cudf_edgelist(cg_edges_gdf, source=\"src\", destination=\"dst\", edge_attr='data', renumber=True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 15,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "lv_gdf, lv_mod = cugraph.louvain(G) \n",
-    "part_ids = lv_gdf[\"partition\"].unique()\n",
-    "lv_gdf['idx'] = lv_gdf['vertex']\n",
-    "nodes_cg_gdf = nodes_cg_gdf.merge(lv_gdf, on=['idx'], how='left')\n",
-    "nodes_cg_gdf = nodes_cg_gdf.drop(['vertex'], axis=1)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 16,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "-0.031225887345679007"
-      ]
-     },
-     "execution_count": 16,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "lv_mod # Louvain modularity score"
+    "# only run lovain if running on newer than Pascal architecture\n",
+    "if not is_device_version_less_than((7, 0)):\n",
+    "    # Build new graph with edge values required for Louvain\n",
+    "    G = cugraph.Graph()\n",
+    "    G.from_cudf_edgelist(cg_edges_gdf, source=\"src\", destination=\"dst\", edge_attr='data', renumber=True)\n",
+    "\n",
+    "    lv_gdf, lv_mod = cugraph.louvain(G) \n",
+    "    part_ids = lv_gdf[\"partition\"].unique()\n",
+    "    lv_gdf['idx'] = lv_gdf['vertex']\n",
+    "    nodes_cg_gdf = nodes_cg_gdf.merge(lv_gdf, on=['idx'], how='left')\n",
+    "    nodes_cg_gdf = nodes_cg_gdf.drop(['vertex'], axis=1)\n",
+    "\n",
+    "    lv_mod # Louvain modularity score"
    ]
   },
   {
@@ -355,7 +333,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -365,7 +343,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -488,7 +466,7 @@
        "4  [204, 60, 34, 27, 13]  0.018699         19  "
       ]
      },
-     "execution_count": 18,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }


### PR DESCRIPTION
Update network mapping notebook to skip cuGraph Louvain if on Pascal architecture. gpuCI sometimes uses p100 instances in PR builds resulting in Louvain error.

Closes #358