### PR TITLE
[gpuCI] Forward-merge branch-21.06 to branch-21.08 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-# clx 0.20.0 (Date TBD)
+# clx 21.06.00 (Date TBD)
 
-Please see https://github.com/rapidsai/clx/releases/tag/v0.20.0a for the latest changes to this development branch.
+Please see https://github.com/rapidsai/clx/releases/tag/v21.06.00a for the latest changes to this development branch.
 
 # clx 0.19.0 (21 Apr 2021)
 


### PR DESCRIPTION
Forward-merge triggered by push to `branch-21.06` that creates a PR to keep `branch-21.08` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.