### PR TITLE
[gpuCI] Forward-merge branch-21.06 to branch-21.08 [skip ci]

### DIFF
--- a/conda/environments/clx_dev_cuda10.1.yml
+++ b/conda/environments/clx_dev_cuda10.1.yml
@@ -10,10 +10,10 @@ channels:
 - auto
 dependencies:
 - numpy>=1.17.3,<1.19.0
-- cugraph=0.20.*
-- cuml=0.20.*
-- cuxfilter=0.20.*
-- dask-cudf=0.20.*
+- cugraph=21.06.*
+- cuml=21.06.*
+- cuxfilter=21.06.*
+- dask-cudf=21.06.*
 - cupy>7.1.0,<9.0.0a0
 - cudatoolkit=10.1
 - pytorch=1.7.1

--- a/conda/environments/clx_dev_cuda10.2.yml
+++ b/conda/environments/clx_dev_cuda10.2.yml
@@ -10,10 +10,10 @@ channels:
 - auto
 dependencies:
 - numpy>=1.17.3,<1.19.0
-- cugraph=0.20.*
-- cuml=0.20.*
-- cuxfilter=0.20.*
-- dask-cudf=0.20.*
+- cugraph=21.06.*
+- cuml=21.06.*
+- cuxfilter=21.06.*
+- dask-cudf=21.06.*
 - cupy>7.1.0,<9.0.0a0
 - cudatoolkit=10.2
 - pytorch=1.7.1

--- a/conda/environments/clx_dev_cuda11.0.yml
+++ b/conda/environments/clx_dev_cuda11.0.yml
@@ -10,10 +10,10 @@ channels:
 - auto
 dependencies:
 - numpy>=1.17.3,<1.19.0
-- cugraph=0.20.*
-- cuml=0.20.*
-- cuxfilter=0.20.*
-- dask-cudf=0.20.*
+- cugraph=21.06.*
+- cuml=21.06.*
+- cuxfilter=21.06.*
+- dask-cudf=21.06.*
 - cupy>7.1.0,<9.0.0a0
 - cudatoolkit=11.0
 - pytorch=1.7.1


### PR DESCRIPTION
Forward-merge triggered by push to `branch-21.06` that creates a PR to keep `branch-21.08` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.