### PR TITLE
Drop `flatbuffers` install

### DIFF
--- a/siem_integrations/Dockerfile
+++ b/siem_integrations/Dockerfile
@@ -15,8 +15,7 @@ RUN apt update -y --fix-missing && \
     apt install -y vim
 
 RUN source activate rapids \
-    && conda install -c blazingsql-nightly/label/cuda${CUDA_VERSION} -c blazingsql-nightly -c rapidsai-nightly -c conda-forge blazingsql \
-    && pip install flatbuffers
+    && conda install -c blazingsql-nightly/label/cuda${CUDA_VERSION} -c blazingsql-nightly -c rapidsai-nightly -c conda-forge blazingsql
 
 RUN source activate rapids \
     && conda install -y -c pytorch pytorch==1.3.1 torchvision=0.4.2 datashader>=0.10.* panel=0.6.* geopandas>=0.6.* pyppeteer s3fs gunicorn djangorestframework django supervisor nginx \


### PR DESCRIPTION
Following up on our conversation offline, this was needed for BSQL at one point, but is no longer needed. So this drops this dependency.

cc @efajardo-nv @Ethyling @BartleyR