### PR TITLE
Update `conda` environment name for CI

### DIFF
--- a/ci/checks/style.sh
+++ b/ci/checks/style.sh
@@ -9,7 +9,8 @@ set +e
 PATH=/conda/bin:$PATH
 
 # Activate common conda env
-source activate gdf
+. /opt/conda/etc/profile.d/conda.sh
+conda activate rapids
 
 # Run flake8 and get results/return code
 FLAKE=`flake8 --ignore=E501,W605 --exclude="factory.py,perfect_hash.py" python`

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -39,7 +39,7 @@ gpuci_logger "Activate conda env"
 conda activate rapids
 
 gpuci_logger "Install conda dependenciess"
-gpuci_conda_retry install -y -c pytorch -c gwerbin \
+gpuci_conda_retry install -y -c pytorch \
     "rapids-build-env=$MINOR_VERSION.*" \
     "rapids-notebook-env=$MINOR_VERSION.*" \
     "cugraph=${MINOR_VERSION}" \
@@ -50,7 +50,7 @@ gpuci_conda_retry install -y -c pytorch -c gwerbin \
     "torchvision" \
     "python-confluent-kafka" \
     "transformers=4.*" \
-    "seqeval=0.0.12" \
+    "seqeval=1.2.2" \
     "python-whois" \
     "requests" \
     "matplotlib" \

--- a/ci/local/README.md
+++ b/ci/local/README.md
@@ -30,7 +30,8 @@ For a full list of available gpuCI docker images, visit our [DockerHub](https://
 Style Check:
 ```bash
 $ bash ci/local/build.sh -r ~/rapids/clx -s
-$ source activate gdf    #Activate gpuCI conda environment
+$ . /opt/conda/etc/profile.d/conda.sh
+$ conda activate rapids
 $ cd rapids
 $ flake8 python
 ```

--- a/conda/environments/clx_dev_cuda11.0.yml
+++ b/conda/environments/clx_dev_cuda11.0.yml
@@ -4,7 +4,6 @@ channels:
 - rapidsai-nightly
 - pytorch
 - conda-forge
-- gwerbin
 dependencies:
 - cudatoolkit=11.0
 - python>=3.6,<3.9

--- a/examples/streamz/Dockerfile
+++ b/examples/streamz/Dockerfile
@@ -63,7 +63,7 @@ EXPOSE 2181
 EXPOSE 9092
 
 RUN source activate rapids && \
-    conda install -c pytorch "pytorch=1.7.1" torchvision "cudf_kafka=${RAPIDS_VERSION}" "custreamz=${RAPIDS_VERSION}" "scikit-learn>=0.21" "nodejs>=12" ipywidgets python-confluent-kafka "transformers=4.*" "seqeval=0.0.12" python-whois seaborn requests matplotlib pytest jupyterlab "openjdk=8.0.152" dask-cuda && \
+    conda install -c pytorch "pytorch=1.7.1" torchvision "cudf_kafka=${RAPIDS_VERSION}" "custreamz=${RAPIDS_VERSION}" "scikit-learn>=0.21" "nodejs>=12" ipywidgets python-confluent-kafka "transformers=4.*" "seqeval=1.2.2" python-whois seaborn requests matplotlib pytest jupyterlab "openjdk=8.0.152" dask-cuda && \
     pip install "git+https://github.com/rapidsai/cudatashader.git" && \
     pip install mockito && \
     pip install wget && \


### PR DESCRIPTION
The `gdf` conda environment has been replaced with the `rapids` environment. A symlink was put in place for `gdf` to continue to work, but the symlink will be removed in the near future. This PR updates all scripts to use the `rapids` environment name.
