### PR TITLE
variable fix so that accuracy_score doesn't throw an error

### DIFF
--- a/notebooks/dga_detection/DGA_Detection.ipynb
+++ b/notebooks/dga_detection/DGA_Detection.ipynb
@@ -997,9 +997,9 @@
     "    true_results.append(list(chunk['type'].values_host))\n",
     "pred_results = np.concatenate(pred_results)\n",
     "true_results = np.concatenate(true_results)\n",
-    "accuracy_score = accuracy_score(pred_results, true_results)\n",
+    "accuracy_score_result = accuracy_score(pred_results, true_results)\n",
     "\n",
-    "print('Model accuracy: %s'%(accuracy_score))"
+    "print('Model accuracy: %s'%(accuracy_score_result))"
    ]
   },
   {


### PR DESCRIPTION
Renames the `accuracy_score` variable to be distinct from the `accuracy_score` function.
 
Closes https://github.com/rapidsai/clx/issues/437