### PR TITLE
Bump `isort` hook to 5.6.4, add non-conflicting profiles for `isort`/`black`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,17 +1,21 @@
 repos:
-  - repo: https://github.com/timothycrosley/isort
-    rev: 5.0.7
+  - repo: https://github.com/pycqa/isort
+    rev: 5.6.4
     hooks:
           - id: isort
+            files: ^python/.*
+            args: ["--settings-path=python/setup.cfg"]
   - repo: https://github.com/ambv/black
     rev: 19.10b0
     hooks:
-    - id: black
+          - id: black
+            files: ^python/.*
   - repo: https://gitlab.com/pycqa/flake8
     rev: 3.8.3
     hooks:
           - id: flake8
             alias: flake8
             name: flake8
+            files: ^python/.*
             args: ["--config=python/.flake8"]
             types: [python]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,19 @@
+[tool.black]
+line-length = 79
+target-version = ["py36"]
+include = '\.py?$'
+exclude = '''
+/(
+    thirdparty |
+    \.eggs |
+    \.git |
+    \.hg |
+    \.mypy_cache |
+    \.tox |
+    \.venv |
+    _build |
+    buck-out |
+    build |
+    dist
+)/
+'''

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -22,3 +22,38 @@ versionfile_source = clx/_version.py
 versionfile_build = clx/_version.py
 tag_prefix = v
 parentdir_prefix = clx-
+
+[isort]
+line_length=79
+multi_line_output=3
+include_trailing_comma=True
+force_grid_wrap=0
+combine_as_imports=True
+order_by_type=True
+known_dask=
+    dask
+    distributed
+    dask_cuda
+known_rapids=
+    rmm
+    cudf
+    cuml
+    cugraph
+    dask_cudf
+known_first_party=
+    clx
+default_section=THIRDPARTY
+sections=FUTURE,STDLIB,THIRDPARTY,DASK,RAPIDS,FIRSTPARTY,LOCALFOLDER
+skip=
+    thirdparty
+    .eggs
+    .git
+    .hg
+    .mypy_cache
+    .tox
+    .venv
+    _build
+    buck-out
+    build
+    dist
+    __init__.py


### PR DESCRIPTION
Bumps the `isort` pre-commit hook to 5.6.4 to correspond with the gpuCI version bump (see rapidsai/integration#286). Also adds profiles for `isort` and `black` so that they will not conflict.