### PR TITLE
Update CLX workflow yaml reader for pyyaml v6.0

### DIFF
--- a/python/clx/workflow/workflow.py
+++ b/python/clx/workflow/workflow.py
@@ -17,6 +17,7 @@ import logging
 import os
 import time
 import yaml
+from yaml import Loader
 from clx.io.factory.factory import Factory
 from abc import ABC, abstractmethod
 
@@ -102,7 +103,7 @@ class Workflow(ABC):
         try:
             config = None
             with open(yaml_file, "r") as ymlfile:
-                config = yaml.load(ymlfile)
+                config = yaml.load(ymlfile, Loader=Loader)
             self._source = config["source"]
             self._destination = config["destination"]
             self._io_reader = Factory.get_reader(self._source["type"], self._source)


### PR DESCRIPTION
The `gpuci/rapidsai` container used for builds recently updated the `pyyaml` package to v6.0 which caused error in CLX workflow yaml reader unit test. This PR updates code to work with new version.