### PR TITLE
[REVIEW] Update to PyTorch 1.10

### DIFF
--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -42,6 +42,7 @@ gpuci_logger "Install conda dependenciess"
 gpuci_mamba_retry install -y -c pytorch \
     "rapids-build-env=$MINOR_VERSION.*" \
     "rapids-notebook-env=$MINOR_VERSION.*" \
+    "cudatoolkit=$CUDA_REL" \
     "cugraph=${MINOR_VERSION}" \
     "cuml=${MINOR_VERSION}" \
     "dask-cuda=${MINOR_VERSION}" \

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -39,7 +39,7 @@ gpuci_logger "Activate conda env"
 conda activate rapids
 
 gpuci_logger "Install conda dependenciess"
-gpuci_mamba_retry install -y -c pytorch \
+gpuci_mamba_retry install -y \
     "rapids-build-env=$MINOR_VERSION.*" \
     "rapids-notebook-env=$MINOR_VERSION.*" \
     "cudatoolkit=$CUDA_REL" \

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -39,14 +39,13 @@ gpuci_logger "Activate conda env"
 conda activate rapids
 
 gpuci_logger "Install conda dependenciess"
-gpuci_conda_retry install -y -c pytorch \
+gpuci_mamba_retry install -y -c pytorch \
     "rapids-build-env=$MINOR_VERSION.*" \
     "rapids-notebook-env=$MINOR_VERSION.*" \
     "cugraph=${MINOR_VERSION}" \
     "cuml=${MINOR_VERSION}" \
     "dask-cuda=${MINOR_VERSION}" \
     "cuxfilter=${MINOR_VERSION}" \
-    "pytorch=1.7.1" \
     "torchvision" \
     "python-confluent-kafka" \
     "transformers=4.*" \
@@ -60,7 +59,7 @@ gpuci_conda_retry install -y -c pytorch \
 # gpuci_conda_retry remove --force rapids-build-env rapids-notebook-env
 # gpuci_conda_retry install -y "your-pkg=1.0.0"
 
-gpuci_logger "Install cudatashader"
+pip install -U torch==1.10.0+cu113 -f https://download.pytorch.org/whl/cu113/torch_stable.html
 pip install "git+https://github.com/rapidsai/cudatashader.git"
 pip install "git+https://github.com/slashnext/SlashNext-URL-Analysis-and-Enrichment.git#egg=slashnext-phishing-ir&subdirectory=Python SDK/src"
 pip install mockito

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -46,9 +46,7 @@ gpuci_mamba_retry install -y -c pytorch \
     "cuml=${MINOR_VERSION}" \
     "dask-cuda=${MINOR_VERSION}" \
     "cuxfilter=${MINOR_VERSION}" \
-    "torchvision" \
     "python-confluent-kafka" \
-    "transformers=4.*" \
     "seqeval=1.2.2" \
     "python-whois" \
     "requests" \

--- a/conda/recipes/clx/meta.yaml
+++ b/conda/recipes/clx/meta.yaml
@@ -29,12 +29,8 @@ requirements:
   run:
     - python
     - mkl
-    - scikit-learn>=0.21
     - cugraph {{ minor_version }}.*
     - cuml {{ minor_version }}.*
-    - pytorch 1.7.1
-    - torchvision
-    - transformers 4.*
 
 about:
   home: http://rapids.ai/

--- a/notebooks/Predictive_Maintenance/Predictive_Maintenance_Sequence_Classifier.ipynb
+++ b/notebooks/Predictive_Maintenance/Predictive_Maintenance_Sequence_Classifier.ipynb
@@ -72,7 +72,7 @@
    "outputs": [],
    "source": [
     "import cudf;\n",
-    "from cuml.preprocessing.model_selection import train_test_split;\n",
+    "from cuml.model_selection import train_test_split;\n",
     "from clx.analytics.binary_sequence_classifier import BinarySequenceClassifier;\n",
     "import s3fs;\n",
     "from os import path;\n",
@@ -123,38 +123,10 @@
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "51badea15db94953b026e4fd553467e1",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Downloading:   0%|          | 0.00/570 [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "95afc2f823834000b3f51b1b70d177f2",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Downloading:   0%|          | 0.00/440M [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Some weights of the model checkpoint at bert-base-uncased were not used when initializing BertForSequenceClassification: ['cls.predictions.transform.LayerNorm.bias', 'cls.seq_relationship.bias', 'cls.predictions.transform.dense.bias', 'cls.predictions.transform.dense.weight', 'cls.predictions.decoder.weight', 'cls.predictions.transform.LayerNorm.weight', 'cls.predictions.bias', 'cls.seq_relationship.weight']\n",
+      "Some weights of the model checkpoint at bert-base-uncased were not used when initializing BertForSequenceClassification: ['cls.predictions.transform.dense.weight', 'cls.predictions.decoder.weight', 'cls.seq_relationship.bias', 'cls.predictions.transform.LayerNorm.weight', 'cls.seq_relationship.weight', 'cls.predictions.transform.dense.bias', 'cls.predictions.transform.LayerNorm.bias', 'cls.predictions.bias']\n",
       "- This IS expected if you are initializing BertForSequenceClassification from the checkpoint of a model trained on another task or with another architecture (e.g. initializing a BertForSequenceClassification model from a BertForPreTraining model).\n",
       "- This IS NOT expected if you are initializing BertForSequenceClassification from the checkpoint of a model that you expect to be exactly identical (initializing a BertForSequenceClassification model from a BertForSequenceClassification model).\n",
       "Some weights of BertForSequenceClassification were not initialized from the model checkpoint at bert-base-uncased and are newly initialized: ['classifier.weight', 'classifier.bias']\n",
@@ -183,7 +155,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -199,36 +171,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Epoch:   0%|          | 0/1 [00:00<?, ?it/s]/opt/conda/envs/rapids/lib/python3.8/site-packages/torch/nn/parallel/_functions.py:64: UserWarning: Was asked to gather along dimension 0, but all input tensors were scalars; will instead unsqueeze and return a vector.\n",
-      "  warnings.warn('Was asked to gather along dimension 0, but all '\n"
+      "Epoch:   0%|          | 0/1 [00:00<?, ?it/s]/opt/conda/envs/rapids/lib/python3.7/site-packages/cudf/core/series.py:1661: FutureWarning: The to_array method will be removed in a future cuDF release. Consider using `to_numpy` instead.\n",
+      "  FutureWarning,\n",
+      "Epoch: 100%|██████████| 1/1 [42:12<00:00, 2532.35s/it]"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Train loss: 0.015383974263815874\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Epoch: 100%|██████████| 1/1 [04:02<00:00, 242.88s/it]"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Validation Accuracy: 0.9994612068965517\n"
+      "Train loss: 0.004649271114368582\n"
      ]
     },
     {
@@ -240,7 +199,7 @@
     }
    ],
    "source": [
-    "seq_classifier.train_model(X_train[\"log\"], y_train, epochs=1)"
+    "seq_classifier.train_model(X_train[\"log\"], y_train, batch_size=8, epochs=1)"
    ]
   },
   {
@@ -259,13 +218,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "0.9996759559300065"
+       "0.9991595643939394"
       ]
      },
      "execution_count": 6,
@@ -286,7 +245,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -295,7 +254,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -312,13 +271,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "0.9919354838709677"
+       "0.978875334721809"
       ]
      },
      "execution_count": 9,
@@ -346,14 +305,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "array([[18141,     6],\n",
-       "       [    0,   369]])"
+       "array([[82751,    71],\n",
+       "       [    0,  1645]])"
       ]
      },
      "execution_count": 10,
@@ -412,7 +371,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.7.12"
   }
  },
  "nbformat": 4,

--- a/notebooks/cybert/cybert_example_training.ipynb
+++ b/notebooks/cybert/cybert_example_training.ipynb
@@ -129,28 +129,28 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>984</th>\n",
+       "      <th>829</th>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
-       "      <td>5.114.231.216 - - [21/Jun/2018:19:09:52 +0200]...</td>\n",
-       "      <td>5.114.231.216</td>\n",
+       "      <td>46.105.57.86 - - [21/Oct/2018:16:52:55 +0200] ...</td>\n",
+       "      <td>46.105.57.86</td>\n",
        "      <td>-</td>\n",
        "      <td>-</td>\n",
-       "      <td>http://www.almhuette-raith.at/apache-log/</td>\n",
-       "      <td>Mozilla/5.0 (Windows NT 6.1; Trident/7.0; rv:1...</td>\n",
-       "      <td>IE</td>\n",
-       "      <td>11.0</td>\n",
+       "      <td>http://almhuette-raith.at/administrator/index....</td>\n",
+       "      <td>Mozilla/5.0 (Linux; U; Android 2.2) AppleWebKi...</td>\n",
+       "      <td>Android</td>\n",
+       "      <td>2.2</td>\n",
        "      <td>...</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
-       "      <td>43192</td>\n",
-       "      <td>206.0</td>\n",
-       "      <td>[21/Jun/2018:19:09:52 +0200]</td>\n",
-       "      <td>1.529608e+12</td>\n",
-       "      <td>2018-06-21T19:09:52</td>\n",
-       "      <td>1.529601e+12</td>\n",
-       "      <td>2018-06-21T19:09:52+02:00</td>\n",
-       "      <td>1.529601e+12</td>\n",
-       "      <td>2018-06-21T17:09:52+00:00</td>\n",
+       "      <td>4494</td>\n",
+       "      <td>200.0</td>\n",
+       "      <td>[21/Oct/2018:16:52:55 +0200]</td>\n",
+       "      <td>1.540141e+12</td>\n",
+       "      <td>2018-10-21T16:52:55</td>\n",
+       "      <td>1.540134e+12</td>\n",
+       "      <td>2018-10-21T16:52:55+02:00</td>\n",
+       "      <td>1.540134e+12</td>\n",
+       "      <td>2018-10-21T14:52:55+00:00</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -159,37 +159,40 @@
       ],
       "text/plain": [
        "    error_level error_message  \\\n",
-       "984        <NA>          <NA>   \n",
+       "829        <NA>          <NA>   \n",
        "\n",
-       "                                                   raw    remote_host  \\\n",
-       "984  5.114.231.216 - - [21/Jun/2018:19:09:52 +0200]...  5.114.231.216   \n",
+       "                                                   raw   remote_host  \\\n",
+       "829  46.105.57.86 - - [21/Oct/2018:16:52:55 +0200] ...  46.105.57.86   \n",
        "\n",
-       "    remote_logname remote_user                     request_header_referer  \\\n",
-       "984              -           -  http://www.almhuette-raith.at/apache-log/   \n",
+       "    remote_logname remote_user  \\\n",
+       "829              -           -   \n",
+       "\n",
+       "                                request_header_referer  \\\n",
+       "829  http://almhuette-raith.at/administrator/index....   \n",
        "\n",
        "                             request_header_user_agent  \\\n",
-       "984  Mozilla/5.0 (Windows NT 6.1; Trident/7.0; rv:1...   \n",
+       "829  Mozilla/5.0 (Linux; U; Android 2.2) AppleWebKi...   \n",
        "\n",
        "    request_header_user_agent__browser__family  \\\n",
-       "984                                         IE   \n",
+       "829                                    Android   \n",
        "\n",
        "    request_header_user_agent__browser__version_string  ...  \\\n",
-       "984                                               11.0  ...   \n",
+       "829                                                2.2  ...   \n",
        "\n",
        "     request_url_username response_bytes_clf status  \\\n",
-       "984                  <NA>              43192  206.0   \n",
+       "829                  <NA>               4494  200.0   \n",
        "\n",
        "                    time_received time_received_datetimeobj  \\\n",
-       "984  [21/Jun/2018:19:09:52 +0200]              1.529608e+12   \n",
+       "829  [21/Oct/2018:16:52:55 +0200]              1.540141e+12   \n",
        "\n",
        "     time_received_isoformat time_received_tz_datetimeobj  \\\n",
-       "984      2018-06-21T19:09:52                 1.529601e+12   \n",
+       "829      2018-10-21T16:52:55                 1.540134e+12   \n",
        "\n",
        "     time_received_tz_isoformat time_received_utc_datetimeobj  \\\n",
-       "984   2018-06-21T19:09:52+02:00                  1.529601e+12   \n",
+       "829   2018-10-21T16:52:55+02:00                  1.540134e+12   \n",
        "\n",
        "     time_received_utc_isoformat  \n",
-       "984    2018-06-21T17:09:52+00:00  \n",
+       "829    2018-10-21T14:52:55+00:00  \n",
        "\n",
        "[1 rows x 37 columns]"
       ]
@@ -301,7 +304,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -328,14 +331,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/opt/conda/envs/clx_dev/lib/python3.8/site-packages/cudf/core/subword_tokenizer.py:187: UserWarning: When truncation is not True, the behaviour currently differs from HuggingFace as cudf always returns overflowing tokens\n",
+      "/opt/conda/envs/rapids/lib/python3.7/site-packages/cudf/core/subword_tokenizer.py:189: UserWarning: When truncation is not True, the behaviour currently differs from HuggingFace as cudf always returns overflowing tokens\n",
       "  warn(warning_msg)\n"
      ]
     },
@@ -343,8 +346,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 1.21 s, sys: 308 ms, total: 1.52 s\n",
-      "Wall time: 2.41 s\n"
+      "CPU times: user 1.22 s, sys: 300 ms, total: 1.52 s\n",
+      "Wall time: 1.52 s\n"
      ]
     }
    ],
@@ -364,7 +367,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -380,14 +383,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'[PAD]': 0, 'B-error_level': 1, 'B-request_header_referer': 2, 'B-request_header_user_agent': 3, 'B-remote_host': 4, 'B-error_message': 5, 'B-request_method': 6, 'I-time_received': 7, 'O': 8, 'I-request_header_user_agent': 9, 'B-time_received': 10, 'B-request_url': 11, 'B-response_bytes_clf': 12, 'I-error_message': 13, 'X': -100}\n"
+      "{'[PAD]': 0, 'O': 1, 'B-request_url': 2, 'B-time_received': 3, 'I-error_message': 4, 'B-remote_host': 5, 'B-error_level': 6, 'I-time_received': 7, 'I-request_header_user_agent': 8, 'B-response_bytes_clf': 9, 'B-request_header_referer': 10, 'B-request_header_user_agent': 11, 'B-error_message': 12, 'B-request_method': 13, 'X': -100}\n"
      ]
     }
    ],
@@ -397,7 +400,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -408,7 +411,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -427,7 +430,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -445,7 +448,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -455,7 +458,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -466,12 +469,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
     "# create dataloader\n",
-    "train_dataloader = DataLoader(dataset=training_dataset, shuffle=True, batch_size=32)\n",
+    "train_dataloader = DataLoader(dataset=training_dataset, shuffle=True, batch_size=8)\n",
     "val_dataloader = DataLoader(dataset=validation_dataset, shuffle=False, batch_size=1)"
    ]
   },
@@ -485,17 +488,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Some weights of the model checkpoint at bert-base-cased were not used when initializing BertForTokenClassification: ['cls.seq_relationship.weight', 'cls.predictions.transform.LayerNorm.weight', 'cls.seq_relationship.bias', 'cls.predictions.transform.dense.weight', 'cls.predictions.bias', 'cls.predictions.decoder.weight', 'cls.predictions.transform.dense.bias', 'cls.predictions.transform.LayerNorm.bias']\n",
+      "Some weights of the model checkpoint at bert-base-cased were not used when initializing BertForTokenClassification: ['cls.seq_relationship.bias', 'cls.predictions.bias', 'cls.seq_relationship.weight', 'cls.predictions.transform.LayerNorm.bias', 'cls.predictions.transform.LayerNorm.weight', 'cls.predictions.transform.dense.weight', 'cls.predictions.transform.dense.bias', 'cls.predictions.decoder.weight']\n",
       "- This IS expected if you are initializing BertForTokenClassification from the checkpoint of a model trained on another task or with another architecture (e.g. initializing a BertForSequenceClassification model from a BertForPreTraining model).\n",
       "- This IS NOT expected if you are initializing BertForTokenClassification from the checkpoint of a model that you expect to be exactly identical (initializing a BertForSequenceClassification model from a BertForSequenceClassification model).\n",
-      "Some weights of BertForTokenClassification were not initialized from the model checkpoint at bert-base-cased and are newly initialized: ['classifier.bias', 'classifier.weight']\n",
+      "Some weights of BertForTokenClassification were not initialized from the model checkpoint at bert-base-cased and are newly initialized: ['classifier.weight', 'classifier.bias']\n",
       "You should probably TRAIN this model on a down-stream task to be able to use it for predictions and inference.\n"
      ]
     }
@@ -518,7 +521,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -542,39 +545,37 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Epoch:   0%|          | 0/2 [00:00<?, ?it/s]/opt/conda/envs/clx_dev/lib/python3.8/site-packages/torch/nn/parallel/_functions.py:64: UserWarning: Was asked to gather along dimension 0, but all input tensors were scalars; will instead unsqueeze and return a vector.\n",
-      "  warnings.warn('Was asked to gather along dimension 0, but all '\n",
-      "Epoch:  50%|█████     | 1/2 [00:27<00:27, 27.29s/it]"
+      "Epoch:  50%|█████     | 1/2 [00:14<00:14, 14.28s/it]"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Train loss: 2.6424157589673998\n"
+      "Train loss: 0.23484498262405396\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Epoch: 100%|██████████| 2/2 [00:39<00:00, 19.55s/it]"
+      "Epoch: 100%|██████████| 2/2 [00:28<00:00, 14.34s/it]"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Train loss: 0.059327621944248676\n",
-      "CPU times: user 55.1 s, sys: 23.6 s, total: 1min 18s\n",
-      "Wall time: 39.1 s\n"
+      "Train loss: 0.002498794225975871\n",
+      "CPU times: user 28.5 s, sys: 156 ms, total: 28.7 s\n",
+      "Wall time: 28.7 s\n"
      ]
     },
     {
@@ -625,7 +626,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -635,30 +636,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "f1 score: 1.000000\n",
-      "Accuracy score: 0.999736\n",
+      "f1 score: 0.997121\n",
+      "Accuracy score: 0.998702\n",
       "                           precision    recall  f1-score   support\n",
       "\n",
-      "              error_level      1.000     1.000     1.000        19\n",
-      "            error_message      1.000     1.000     1.000        19\n",
-      "              remote_host      1.000     1.000     1.000       181\n",
-      "   request_header_referer      1.000     1.000     1.000        85\n",
-      "request_header_user_agent      1.000     1.000     1.000       170\n",
-      "           request_method      1.000     1.000     1.000       181\n",
-      "              request_url      1.000     1.000     1.000       181\n",
-      "       response_bytes_clf      1.000     1.000     1.000       179\n",
-      "            time_received      1.000     1.000     1.000       200\n",
+      "              error_level      0.900     1.000     0.947        18\n",
+      "            error_message      0.895     0.944     0.919        18\n",
+      "              remote_host      1.000     1.000     1.000       182\n",
+      "   request_header_referer      1.000     1.000     1.000        86\n",
+      "request_header_user_agent      1.000     1.000     1.000       165\n",
+      "           request_method      1.000     1.000     1.000       182\n",
+      "              request_url      0.995     1.000     0.997       182\n",
+      "       response_bytes_clf      1.000     1.000     1.000       180\n",
+      "            time_received      0.995     1.000     0.998       200\n",
       "\n",
-      "                micro avg      1.000     1.000     1.000      1215\n",
-      "                macro avg      1.000     1.000     1.000      1215\n",
-      "             weighted avg      1.000     1.000     1.000      1215\n",
+      "                micro avg      0.995     0.999     0.997      1213\n",
+      "                macro avg      0.976     0.994     0.985      1213\n",
+      "             weighted avg      0.995     0.999     0.997      1213\n",
       "\n"
      ]
     }
@@ -726,7 +727,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -736,7 +737,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -760,7 +761,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.7.12"
   }
  },
  "nbformat": 4,

--- a/notebooks/phish_detection/Phishing_Detection_using_Bert_CLX.ipynb
+++ b/notebooks/phish_detection/Phishing_Detection_using_Bert_CLX.ipynb
@@ -186,21 +186,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Some weights of the model checkpoint at bert-base-uncased were not used when initializing BertForSequenceClassification: ['cls.predictions.bias', 'cls.predictions.transform.dense.weight', 'cls.predictions.transform.dense.bias', 'cls.predictions.decoder.weight', 'cls.seq_relationship.weight', 'cls.seq_relationship.bias', 'cls.predictions.transform.LayerNorm.weight', 'cls.predictions.transform.LayerNorm.bias']\n",
-      "- This IS expected if you are initializing BertForSequenceClassification from the checkpoint of a model trained on another task or with another architecture (e.g. initializing a BertForSequenceClassification model from a BertForPreTraining model).\n",
-      "- This IS NOT expected if you are initializing BertForSequenceClassification from the checkpoint of a model that you expect to be exactly identical (initializing a BertForSequenceClassification model from a BertForSequenceClassification model).\n",
-      "Some weights of BertForSequenceClassification were not initialized from the model checkpoint at bert-base-uncased and are newly initialized: ['classifier.weight', 'classifier.bias']\n",
-      "You should probably TRAIN this model on a down-stream task to be able to use it for predictions and inference.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "seq_classifier = BinarySequenceClassifier()\n",
     "seq_classifier.init_model(\"bert-base-uncased\")\n",
@@ -243,14 +231,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Epoch: 100%|██████████| 1/1 [01:16<00:00, 76.88s/it]"
+      "Epoch: 100%|██████████| 1/1 [01:50<00:00, 110.37s/it]"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Train loss: 0.07324873915204566\n"
+      "Train loss: 0.0431467487288826\n"
      ]
     },
     {
@@ -262,7 +250,8 @@
     }
    ],
    "source": [
-    "seq_classifier.train_model(X_train[\"email\"], y_train, epochs=1)"
+    "seq_classifier.train_model(X_train[\"email\"], y_train, batch_size=6, epochs=1)\n",
+    "# seq_classifier.train_model(X_train[\"email\"], y_train, epochs=1)"
    ]
   },
   {
@@ -280,7 +269,7 @@
     {
      "data": {
       "text/plain": [
-       "0.9920833333333333"
+       "0.9979166666666667"
       ]
      },
      "execution_count": 12,
@@ -354,14 +343,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Epoch: 100%|██████████| 1/1 [00:21<00:00, 21.95s/it]"
+      "Epoch: 100%|██████████| 1/1 [00:30<00:00, 30.51s/it]"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Train loss: 0.4015698071614087\n"
+      "Train loss: 0.15842007496790186\n"
      ]
     },
     {
@@ -373,7 +362,7 @@
     }
    ],
    "source": [
-    "seq_classifier.train_model(X_train[\"email\"], y_train, epochs=1)"
+    "seq_classifier.train_model(X_train[\"email\"], y_train, batch_size=6, epochs=1)"
    ]
   },
   {
@@ -391,7 +380,7 @@
     {
      "data": {
       "text/plain": [
-       "0.9217687074829932"
+       "0.9828514739229025"
       ]
      },
      "execution_count": 16,
@@ -453,14 +442,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Epoch: 100%|██████████| 1/1 [01:40<00:00, 100.65s/it]"
+      "Epoch: 100%|██████████| 1/1 [02:21<00:00, 141.48s/it]"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Train loss: 0.028412134918985275\n"
+      "Train loss: 0.037085937414915476\n"
      ]
     },
     {
@@ -472,7 +461,7 @@
     }
    ],
    "source": [
-    "seq_classifier.train_model(X_train[\"email\"], y_train, epochs=1)"
+    "seq_classifier.train_model(X_train[\"email\"], y_train, batch_size=6, epochs=1)"
    ]
   },
   {
@@ -490,7 +479,7 @@
     {
      "data": {
       "text/plain": [
-       "0.9944661458333334"
+       "0.9973958333333334"
       ]
      },
      "execution_count": 20,
@@ -558,14 +547,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Epoch: 100%|██████████| 1/1 [02:48<00:00, 168.26s/it]"
+      "Epoch: 100%|██████████| 1/1 [03:51<00:00, 231.80s/it]"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Train loss: 0.012522204873560637\n"
+      "Train loss: 0.011595211562038951\n"
      ]
     },
     {
@@ -577,7 +566,7 @@
     }
    ],
    "source": [
-    "seq_classifier.train_model(X_train[\"email\"], y_train, epochs=1)"
+    "seq_classifier.train_model(X_train[\"email\"], y_train, batch_size=6, epochs=1)"
    ]
   },
   {
@@ -595,7 +584,7 @@
     {
      "data": {
       "text/plain": [
-       "0.9988132911392406"
+       "0.9974287974683544"
       ]
      },
      "execution_count": 24,
@@ -660,7 +649,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.10"
+   "version": "3.7.12"
   }
  },
  "nbformat": 4,

--- a/notebooks/pii_detection/pii_detection_training_example.ipynb
+++ b/notebooks/pii_detection/pii_detection_training_example.ipynb
@@ -200,8 +200,8 @@
     "training_dataset, validation_dataset = random_split(dataset, (train_size, (dataset_size-train_size)))\n",
     "\n",
     "# create dataloaders\n",
-    "train_dataloader = DataLoader(dataset=training_dataset, shuffle=True, batch_size=32)\n",
-    "val_dataloader = DataLoader(dataset=validation_dataset, shuffle=False, batch_size=64)"
+    "train_dataloader = DataLoader(dataset=training_dataset, shuffle=True, batch_size=8)\n",
+    "val_dataloader = DataLoader(dataset=validation_dataset, shuffle=False, batch_size=16)"
    ]
   },
   {
@@ -453,7 +453,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.10"
+   "version": "3.7.12"
   }
  },
  "nbformat": 4,

--- a/python/clx/analytics/anomaly_detection.py
+++ b/python/clx/analytics/anomaly_detection.py
@@ -4,7 +4,7 @@ import cuml
 
 def dbscan(feature_dataframe, min_samples=3, eps=0.3):
     """
-    Pass a feature dataframe to this function to detect anomalies in your feature dataframe. This function uses ``cugraph`` DBSCAN to detect anomalies
+    Pass a feature dataframe to this function to detect anomalies in your feature dataframe. This function uses ``cuML`` DBSCAN to detect anomalies
     and outputs associated labels 0,1,-1.
 
     Parameters

--- a/python/clx/analytics/binary_sequence_classifier.py
+++ b/python/clx/analytics/binary_sequence_classifier.py
@@ -85,10 +85,10 @@ class BinarySequenceClassifier(SequenceClassifier):
                     b_input_ids, token_type_ids=None, attention_mask=b_input_mask
                 )[0]
                 b_probs = torch.sigmoid(logits[:, 1])
-                b_preds = b_probs.ge(threshold)
+                b_preds = b_probs.ge(threshold).type(torch.int8)
 
             b_probs = cudf.io.from_dlpack(to_dlpack(b_probs))
-            b_preds = cudf.io.from_dlpack(to_dlpack(b_preds))
+            b_preds = cudf.io.from_dlpack(to_dlpack(b_preds)).astype("boolean")
             preds = preds.append(b_preds)
             probs = probs.append(b_probs)
 

--- a/python/clx/analytics/sequence_classifier.py
+++ b/python/clx/analytics/sequence_classifier.py
@@ -79,7 +79,7 @@ class SequenceClassifier(ABC):
             for df in train_dataloader.get_chunks():
                 b_input_ids, b_input_mask = self._bert_uncased_tokenize(df["text"], max_seq_len)
 
-                b_labels = torch.tensor(df["label"].to_array())
+                b_labels = torch.tensor(df["label"].to_numpy())
                 self._optimizer.zero_grad()  # Clear out the gradients
                 loss = self._model(b_input_ids, token_type_ids=None, attention_mask=b_input_mask, labels=b_labels)[0]  # forwardpass
 
@@ -122,7 +122,7 @@ class SequenceClassifier(ABC):
         nb_eval_steps = 0
         for df in test_dataloader.get_chunks():
             b_input_ids, b_input_mask = self._bert_uncased_tokenize(df["text"], max_seq_len)
-            b_labels = torch.tensor(df["label"].to_array())
+            b_labels = torch.tensor(df["label"].to_numpy())
             with torch.no_grad():
                 logits = self._model(
                     b_input_ids, token_type_ids=None, attention_mask=b_input_mask

--- a/python/clx/tests/test_anomaly_detection.py
+++ b/python/clx/tests/test_anomaly_detection.py
@@ -44,6 +44,6 @@ def test_anomaly_detection():
     )
     fdf = clx.features.frequency(df, "user", "computer")  # Create feature data
     actual = clx.analytics.anomaly_detection.dbscan(fdf, min_samples=2, eps=0.5)
-    expected = cudf.Series([-1, -1], dtype="int32")
-    expected.index = cudf.Series([0, 3])
+    expected = cudf.Series([-1, -1], dtype="int32", index=None)
+    expected.index = cudf.Series(["u1", "u4"])
     assert actual.equals(expected)


### PR DESCRIPTION
- Update gpu build to use `gpuci_mamba_retry`
- Update gpu build to pip install latest stable PyTorch (v1.10). Replaces conda install of PyTorch 1.7.1 which was tying us to CUDA 11.0. `conda` and `mamba` would often install cpu version of PyTorch on RAPIDS-supported CUDA versions. PyTorch 1.10 officially supports CUDA 11.3. By pip installing, gpu build can now also be run against CUDA 11.2, 11.4 and 11.5.
- Remove PyTorch from conda recipe. See above.
- Update anomaly detection unit test after upstream cuml changes to dbscan.