### PR TITLE
[gpuCI] Forward-merge branch-21.12 to branch-22.02 [skip gpuci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
-# clx 21.12.00 (Date TBD)
+# clx 21.12.00 (9 Dec 2021)
 
-Please see https://github.com/rapidsai/clx/releases/tag/v21.12.00a for the latest changes to this development branch.
+## 🐛 Bug Fixes
+
+- Update sequence_classifier.py ([#459](https://github.com/rapidsai/clx/pull/459)) [@raykallen](https://github.com/raykallen)
+- Update CLX workflow yaml reader for pyyaml v6.0 ([#458](https://github.com/rapidsai/clx/pull/458)) [@efajardo-nv](https://github.com/efajardo-nv)
+
+## 🛠️ Improvements
+
+- Fix Changelog Merge Conflicts for `branch-21.12` ([#463](https://github.com/rapidsai/clx/pull/463)) [@ajschmidt8](https://github.com/ajschmidt8)
+- Update to PyTorch 1.10 ([#460](https://github.com/rapidsai/clx/pull/460)) [@efajardo-nv](https://github.com/efajardo-nv)
 
 # clx 21.10.00 (7 Oct 2021)
 


### PR DESCRIPTION
Forward-merge triggered by push to `branch-21.12` that creates a PR to keep `branch-22.02` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.