### PR TITLE
Build packages using mambabuild

### DIFF
--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright (c) 2020, NVIDIA CORPORATION.
+# Copyright (c) 2020-2022, NVIDIA CORPORATION.
 ################################################################################
 # CLX cpu build
 ################################################################################
@@ -53,12 +53,15 @@ conda list --show-channel-urls
 # FIX Added to deal with Anancoda SSL verification issues during conda builds
 conda config --set ssl_verify False
 
+# FIXME: Remove
+gpuci_mamba_retry install -c conda-forge boa
+
 ###############################################################################
 # BUILD - Conda package build
 ################################################################################
 
 gpuci_logger "Build conda pkg for clx"
-conda build conda/recipes/clx
+gpuci_conda_retry mambabuild conda/recipes/clx
 
 ################################################################################
 # UPLOAD - Conda package

--- a/ci/gpu/build.sh
+++ b/ci/gpu/build.sh
@@ -66,10 +66,13 @@ conda list --show-channel-urls
 # BUILD - Build clx
 ################################################################################
 
+#TODO: Move boa installation to gpuci/rapidsai
+gpuci_mamba_retry install boa
+
 gpuci_logger "Build and install clx..."
 cd "${WORKSPACE}"
 CONDA_BLD_DIR="${WORKSPACE}/.conda-bld"
-gpuci_conda_retry build --croot "${CONDA_BLD_DIR}" conda/recipes/clx
+gpuci_conda_retry mambabuild --croot "${CONDA_BLD_DIR}" conda/recipes/clx
 gpuci_mamba_retry install -c "${CONDA_BLD_DIR}" clx
 
 ################################################################################


### PR DESCRIPTION
Use `mambabuild` to build `conda` packages. This should speed up the builds and help to debug `conda` conflict issues