### PR TITLE
[gpuCI] Forward-merge branch-22.02 to branch-22.04 [skip gpuci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-# clx 22.02.00 (Date TBD)
+# clx 22.02.00 (2 Feb 2022)
 
-Please see https://github.com/rapidsai/clx/releases/tag/v22.02.00a for the latest changes to this development branch.
+
 
 # clx 21.12.00 (9 Dec 2021)
 


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.02` that creates a PR to keep `branch-22.04` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.