### PR TITLE
Add `.github/ops-bot.yaml` config file [skip ci]

### DIFF
--- a/.github/ops-bot.yaml
+++ b/.github/ops-bot.yaml
@@ -1,0 +1,8 @@
+# This file controls which features from the `ops-bot` repository below are enabled.
+# - repo: https://github.com/rapidsai/ops-bot
+
+auto_merger: true
+branch_checker: true
+label_checker: true
+release_drafter: true
+external_contributors: true

--- a/.github/ops-bot.yaml
+++ b/.github/ops-bot.yaml
@@ -1,5 +1,5 @@
 # This file controls which features from the `ops-bot` repository below are enabled.
-# - repo: https://github.com/rapidsai/ops-bot
+# - https://github.com/rapidsai/ops-bot
 
 auto_merger: true
 branch_checker: true


### PR DESCRIPTION
In the near future, the [rapidsai/ops-bot](https://github.com/rapidsai/ops-bot) GitHub application that we use for GitHub automation will be enabled on all repositories in the `rapidsai` GitHub organization. Since not all features of the application are applicable to all repositories, this PR adds a new file, `.github/ops-bot.yaml`, which can configure which features are enabled per repository.
