### PR TITLE
[gpuCI] Forward-merge branch-22.04 to branch-22.06 [skip gpuci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
-# clx 22.04.00 (Date TBD)
+# clx 22.04.00 (6 Apr 2022)
 
-Please see https://github.com/rapidsai/clx/releases/tag/v22.04.00a for the latest changes to this development branch.
+## 🛠️ Improvements
+
+- Temporarily disable new `ops-bot` functionality ([#478](https://github.com/rapidsai/clx/pull/478)) [@ajschmidt8](https://github.com/ajschmidt8)
+- Add `.github/ops-bot.yaml` config file ([#477](https://github.com/rapidsai/clx/pull/477)) [@ajschmidt8](https://github.com/ajschmidt8)
+- removed deprecated function to_array ([#474](https://github.com/rapidsai/clx/pull/474)) [@bsuryadevara](https://github.com/bsuryadevara)
 
 # clx 22.02.00 (2 Feb 2022)
 


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.04` that creates a PR to keep `branch-22.06` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.