### PR TITLE
[gpuCI] Forward-merge branch-22.06 to branch-22.08 [skip gpuci]

### DIFF
--- a/conda/recipes/clx/conda_build_config.yaml
+++ b/conda/recipes/clx/conda_build_config.yaml
@@ -1,0 +1,8 @@
+c_compiler_version:
+  - 9
+
+cxx_compiler_version:
+  - 9
+
+sysroot_version:
+  - "2.17"

--- a/conda/recipes/clx/meta.yaml
+++ b/conda/recipes/clx/meta.yaml
@@ -19,12 +19,13 @@ build:
   string: py{{ py_version }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
   script_env:
     - VERSION_SUFFIX
-    - CC
-    - CXX
-    - CUDAHOSTCXX
 
 requirements:
   build:
+    - {{ compiler('c') }}
+    - sysroot_linux-64 {{ sysroot_version }}  # [linux64]
+    - sysroot_linux-aarch64 {{ sysroot_version }}  # [aarch64]
+  host:
     - python
   run:
     - python


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.06` that creates a PR to keep `branch-22.08` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.