### PR TITLE
[gpuCI] Forward-merge branch-22.10 to branch-22.12 [skip gpuci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-# clx 22.10.00 (Date TBD)
+# clx 22.10.00 (12 Oct 2022)
 
-Please see https://github.com/rapidsai/clx/releases/tag/v22.10.00a for the latest changes to this development branch.
+
 
 # clx 22.08.00 (Date TBD)
 


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.10` that creates a PR to keep `branch-22.12` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.