### PR TITLE
[gpuCI] Forward-merge branch-22.12 to branch-23.02 [skip gpuci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
-# clx 22.12.00 (Date TBD)
+# clx 22.12.00 (8 Dec 2022)
 
-Please see https://github.com/rapidsai/clx/releases/tag/v22.12.00a for the latest changes to this development branch.
+## 🛠️ Improvements
+
+- Remove stale labeler ([#514](https://github.com/rapidsai/clx/pull/514)) [@raydouglass](https://github.com/raydouglass)
 
 # clx 22.10.00 (12 Oct 2022)
 


### PR DESCRIPTION
Forward-merge triggered by push to `branch-22.12` that creates a PR to keep `branch-23.02` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.