### PR TITLE
Enable copy_prs.

### DIFF
--- a/.github/ops-bot.yaml
+++ b/.github/ops-bot.yaml
@@ -6,3 +6,4 @@ branch_checker: true
 label_checker: true
 release_drafter: true
 external_contributors: false
+copy_prs: true


### PR DESCRIPTION
Needed for GitHub Actions migration.