### PR TITLE
Update Rapids datasets download URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,13 +173,14 @@ CLX is targeted towards cybersecurity data scientists, senior security analysts,
 
 ```python
 import cudf
-import s3fs
+import requests
 from os import path
 
 # download data
-if not path.exists("./splunk_faker_raw4"):
-    fs = s3fs.S3FileSystem(anon=True)
-    fs.get("rapidsai-data/cyber/clx/splunk_faker_raw4", "./splunk_faker_raw4")
+if not path.exists('./splunk_faker_raw4'):
+    url = 'https://data.rapids.ai/cyber/clx/splunk_faker_raw4'
+    r = requests.get(url)
+    open('./splunk_faker_raw4', 'wb').write(r.content)
 
 # read in alert data
 gdf = cudf.read_csv('./splunk_faker_raw4')

--- a/examples/forest_inference/FIL_custreamz_pipeline.ipynb
+++ b/examples/forest_inference/FIL_custreamz_pipeline.ipynb
@@ -25,13 +25,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import s3fs\n",
+    "import requests\n",
     "from os import path\n",
     "\n",
     "# Download sample data and model\n",
     "IOT_MALWARE_JSON=\"iot_malware_1_1.json\"\n",
     "IOT_XGBOOST_MODEL=\"iot_xgboost_model.bst\"\n",
-    "S3_BASE_PATH = \"rapidsai-data/cyber/clx\""
+    "DATA_BASE_URL = \"https://data.rapids.ai/cyber/clx/\""
    ]
   },
   {
@@ -42,8 +42,8 @@
    "source": [
     "# xgboost model\n",
     "if not path.exists(IOT_XGBOOST_MODEL):\n",
-    "    fs = s3fs.S3FileSystem(anon=True)\n",
-    "    fs.get(S3_BASE_PATH + \"/\" + IOT_XGBOOST_MODEL, IOT_XGBOOST_MODEL)"
+    "    r = requests.get(DATA_BASE_URL + IOT_XGBOOST_MODEL)\n",
+    "    open(IOT_XGBOOST_MODEL, 'wb').write(r.content)"
    ]
   },
   {
@@ -54,8 +54,8 @@
    "source": [
     "# IoT data in json format\n",
     "if not path.exists(IOT_MALWARE_JSON):\n",
-    "    fs = s3fs.S3FileSystem(anon=True)\n",
-    "    fs.get(S3_BASE_PATH + \"/\" + IOT_MALWARE_JSON, IOT_MALWARE_JSON)"
+    "    r = requests.get(DATA_BASE_URL + IOT_MALWARE_JSON)\n",
+    "    open(IOT_MALWARE_JSON, 'wb').write(r.content)"
    ]
   },
   {

--- a/examples/forest_inference/xgboost_streamz_pipeline.ipynb
+++ b/examples/forest_inference/xgboost_streamz_pipeline.ipynb
@@ -24,13 +24,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import s3fs\n",
+    "import requests\n",
     "from os import path\n",
     "\n",
     "# Download sample data and model\n",
     "IOT_MALWARE_JSON=\"iot_malware_1_1.json\"\n",
     "IOT_XGBOOST_MODEL=\"iot_xgboost_model.bst\"\n",
-    "S3_BASE_PATH = \"rapidsai-data/cyber/clx\""
+    "DATA_BASE_URL = \"https://data.rapids.ai/cyber/clx/\""
    ]
   },
   {
@@ -41,8 +41,8 @@
    "source": [
     "# xgboost model\n",
     "if not path.exists(IOT_XGBOOST_MODEL):\n",
-    "    fs = s3fs.S3FileSystem(anon=True)\n",
-    "    fs.get(S3_BASE_PATH + \"/\" + IOT_XGBOOST_MODEL, IOT_XGBOOST_MODEL)"
+    "    r = requests.get(DATA_BASE_URL + IOT_XGBOOST_MODEL)\n",
+    "    open(IOT_XGBOOST_MODEL, 'wb').write(r.content)"
    ]
   },
   {
@@ -53,8 +53,8 @@
    "source": [
     "# IoT data in json format\n",
     "if not path.exists(IOT_MALWARE_JSON):\n",
-    "    fs = s3fs.S3FileSystem(anon=True)\n",
-    "    fs.get(S3_BASE_PATH + \"/\" + IOT_MALWARE_JSON, IOT_MALWARE_JSON)"
+    "    r = requests.get(DATA_BASE_URL + IOT_MALWARE_JSON)\n",
+    "    open(IOT_MALWARE_JSON, 'wb').write(r.content)"
    ]
   },
   {

--- a/examples/forest_inference/xgboost_training.ipynb
+++ b/examples/forest_inference/xgboost_training.ipynb
@@ -32,7 +32,7 @@
     "import cudf\n",
     "from cuml.preprocessing.model_selection import train_test_split\n",
     "\n",
-    "import s3fs\n",
+    "import requests\n",
     "from os import path"
    ]
   },
@@ -51,12 +51,12 @@
    "source": [
     "# Download sample data and model\n",
     "IOT_MALWARE_JSON=\"iot_malware_1_1.json\"\n",
-    "S3_BASE_PATH = \"rapidsai-data/cyber/clx\"\n",
+    "DATA_BASE_URL = \"https://data.rapids.ai/cyber/clx/\"\n",
     "\n",
     "# IoT data in json format\n",
     "if not path.exists(IOT_MALWARE_JSON):\n",
-    "    fs = s3fs.S3FileSystem(anon=True)\n",
-    "    fs.get(S3_BASE_PATH + \"/\" + IOT_MALWARE_JSON, IOT_MALWARE_JSON)\n",
+    "    r = requests.get(DATA_BASE_URL + IOT_MALWARE_JSON)\n",
+    "    open(IOT_MALWARE_JSON, 'wb').write(r.content)\n",
     "    "
    ]
   },

--- a/examples/streamz/Dockerfile
+++ b/examples/streamz/Dockerfile
@@ -50,11 +50,11 @@ RUN wget -q http://models.huggingface.co.s3.amazonaws.com/bert/raykallen/cybert_
 RUN wget -q http://models.huggingface.co.s3.amazonaws.com/bert/raykallen/cybert_apache_parser/pytorch_model.bin -O "$CLX_STREAMZ_HOME"/ml/models/cybert/pytorch_model.bin
 
 # Download apache logs
-RUN wget -q https://rapidsai-data.s3.us-east-2.amazonaws.com/cyber/clx/apache_raw_sample_1k.txt -O "$CLX_STREAMZ_HOME"/data/apache_raw_sample_1k.txt
+RUN wget -q https://data.rapids.ai/cyber/clx/apache_raw_sample_1k.txt -O "$CLX_STREAMZ_HOME"/data/apache_raw_sample_1k.txt
 
 # Download dga detection model and sample input data
-RUN wget -q https://rapidsai-data.s3.us-east-2.amazonaws.com/cyber/clx/dga_detection_pytorch_model.bin -O "$CLX_STREAMZ_HOME"/ml/models/dga/pytorch_model.bin
-RUN wget -q https://rapidsai-data.s3.us-east-2.amazonaws.com/cyber/clx/dga_detection_input.jsonlines -O "$CLX_STREAMZ_HOME"/data/dga_detection_input.jsonlines
+RUN wget -q https://data.rapids.ai/cyber/clx/dga_detection_pytorch_model.bin -O "$CLX_STREAMZ_HOME"/ml/models/dga/pytorch_model.bin
+RUN wget -q https://data.rapids.ai/cyber/clx/dga_detection_input.jsonlines -O "$CLX_STREAMZ_HOME"/data/dga_detection_input.jsonlines
 
 # Zookeeper
 EXPOSE 2181

--- a/notebooks/alert_analysis/Alert_Analysis_with_CLX.ipynb
+++ b/notebooks/alert_analysis/Alert_Analysis_with_CLX.ipynb
@@ -66,7 +66,7 @@
     "from cuxfilter.charts import datashader, bokeh\n",
     "import panel as pn\n",
     "\n",
-    "import s3fs\n",
+    "import requests\n",
     "from os import path"
    ]
   },
@@ -108,8 +108,8 @@
    "outputs": [],
    "source": [
     "if not path.exists(\"./splunk_faker_raw4\"):\n",
-    "    fs = s3fs.S3FileSystem(anon=True)\n",
-    "    fs.get(\"rapidsai-data/cyber/clx/splunk_faker_raw4\", \"./splunk_faker_raw4\")"
+    "    r = requests.get('https://data.rapids.ai/cyber/clx/splunk_faker_raw4')\n",
+    "    open('./splunk_faker_raw4', 'wb').write(r.content)"
    ]
   },
   {

--- a/notebooks/cybert/cybert_example_training.ipynb
+++ b/notebooks/cybert/cybert_example_training.ipynb
@@ -27,7 +27,7 @@
    "outputs": [],
    "source": [
     "from os import path\n",
-    "import s3fs\n",
+    "import requests\n",
     "import torch\n",
     "import torch.nn as nn\n",
     "import torch.nn.functional as F\n",
@@ -62,11 +62,11 @@
    "source": [
     "# download log data\n",
     "APACHE_SAMPLE_CSV = \"apache_sample_1k.csv\"\n",
-    "S3_BASE_PATH = \"rapidsai-data/cyber/clx\"\n",
+    "DATA_BASE_URL = \"https://data.rapids.ai/cyber/clx/\"\n",
     "\n",
     "if not path.exists(APACHE_SAMPLE_CSV):\n",
-    "    fs = s3fs.S3FileSystem(anon=True)\n",
-    "    fs.get(S3_BASE_PATH + \"/\" + APACHE_SAMPLE_CSV, APACHE_SAMPLE_CSV)"
+    "    r = requests.get(DATA_BASE_URL + APACHE_SAMPLE_CSV)\n",
+    "    open(APACHE_SAMPLE_CSV, 'wb').write(r.content)"
    ]
   },
   {

--- a/notebooks/cybert/cybert_log_parsing.ipynb
+++ b/notebooks/cybert/cybert_log_parsing.ipynb
@@ -25,6 +25,7 @@
    "outputs": [],
    "source": [
     "import cudf\n",
+    "import requests\n",
     "import s3fs\n",
     "from os import path\n",
     "\n",
@@ -37,7 +38,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "CLX_S3_BASE_PATH = \"rapidsai-data/cyber/clx\"\n",
+    "DATA_BASE_URL = \"https://data.rapids.ai/cyber/clx/\"\n",
     "HF_S3_BASE_PATH = \"models.huggingface.co/bert/raykallen/cybert_apache_parser\"\n",
     "\n",
     "CONFIG_FILENAME = \"config.json\"\n",
@@ -114,8 +115,8 @@
    "outputs": [],
    "source": [
     "if not path.exists(APACHE_SAMPLE_CSV):\n",
-    "    fs = s3fs.S3FileSystem(anon=True)\n",
-    "    fs.get(CLX_S3_BASE_PATH + \"/\" + APACHE_SAMPLE_CSV, APACHE_SAMPLE_CSV)"
+    "    r = requests.get(DATA_BASE_URL + APACHE_SAMPLE_CSV)\n",
+    "    open(APACHE_SAMPLE_CSV, 'wb').write(r.content)"
    ]
   },
   {

--- a/notebooks/dga_detection/DGA_Detection.ipynb
+++ b/notebooks/dga_detection/DGA_Detection.ipynb
@@ -35,7 +35,7 @@
     "import os\n",
     "import cudf\n",
     "import torch\n",
-    "import s3fs\n",
+    "import requests\n",
     "import logging\n",
     "import numpy as np\n",
     "from datetime import datetime\n",
@@ -83,7 +83,7 @@
    "source": [
     "INPUT_CSV = \"benign_and_dga_domains.csv\"\n",
     "\n",
-    "S3_BASE_PATH = \"rapidsai-data/cyber/clx\""
+    "DATA_BASE_URL = \"https://data.rapids.ai/cyber/clx/\""
    ]
   },
   {
@@ -94,8 +94,8 @@
    "source": [
     "# Read Benign and DGA dataset\n",
     "if not os.path.exists(INPUT_CSV):\n",
-    "    fs = s3fs.S3FileSystem(anon=True)\n",
-    "    fs.get(S3_BASE_PATH + \"/\" + INPUT_CSV, INPUT_CSV)"
+    "    r = requests.get(DATA_BASE_URL + INPUT_CSV)\n",
+    "    open(INPUT_CSV, 'wb').write(r.content)"
    ]
   },
   {

--- a/notebooks/loda_anomaly_detection/LODA_anomaly_detection.ipynb
+++ b/notebooks/loda_anomaly_detection/LODA_anomaly_detection.ipynb
@@ -42,7 +42,7 @@
     "import matplotlib.pylab as plt \n",
     "import cuml.metrics as mt\n",
     "import wget\n",
-    "import s3fs;\n",
+    "import requests;\n",
     "from os import path;\n",
     "%matplotlib inline \n",
     "\n",
@@ -64,11 +64,11 @@
    "outputs": [],
    "source": [
     "SHUTTLE_CSV = \"shuttle.csv\"\n",
-    "S3_BASE_PATH = \"rapidsai-data/cyber/clx\"\n",
+    "DATA_BASE_URL = \"https://data.rapids.ai/cyber/clx/\"\n",
     "\n",
     "if not path.exists(SHUTTLE_CSV):\n",
-    "    fs = s3fs.S3FileSystem(anon=True)\n",
-    "    fs.get(S3_BASE_PATH + \"/\" + SHUTTLE_CSV, SHUTTLE_CSV)\n",
+    "    r = requests.get(DATA_BASE_URL + SHUTTLE_CSV)\n",
+    "    open(SHUTTLE_CSV, 'wb').write(r.content)\n",
     "    \n",
     "df = cudf.read_csv(SHUTTLE_CSV)"
    ]

--- a/notebooks/network_mapping/CLX_Supervised_Asset_Classification.ipynb
+++ b/notebooks/network_mapping/CLX_Supervised_Asset_Classification.ipynb
@@ -66,7 +66,7 @@
     "from sklearn.metrics import accuracy_score, f1_score, confusion_matrix\n",
     "import pandas as pd\n",
     "from os import path\n",
-    "import s3fs"
+    "import requests"
    ]
   },
   {
@@ -277,13 +277,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "S3_BASE_PATH = \"rapidsai-data/cyber/clx\"\n",
+    "DATA_BASE_URL = \"https://data.rapids.ai/cyber/clx/\"\n",
     "WINEVT_PREPROC_CSV = \"win_events_features_preproc.csv\"\n",
     "\n",
     "# Download Zeek conn log\n",
     "if not path.exists(WINEVT_PREPROC_CSV):\n",
-    "    fs = s3fs.S3FileSystem(anon=True)\n",
-    "    fs.get(S3_BASE_PATH + \"/\" + WINEVT_PREPROC_CSV, WINEVT_PREPROC_CSV)\n",
+    "    r = requests.get(DATA_BASE_URL + WINEVT_PREPROC_CSV)\n",
+    "    open(WINEVT_PREPROC_CSV, 'wb').write(r.content)\n",
     "\n",
     "win_events_gdf = cudf.read_csv(\"win_events_features_preproc.csv\")"
    ]

--- a/notebooks/network_mapping/Network_Mapping_With_RAPIDS_And_CLX.ipynb
+++ b/notebooks/network_mapping/Network_Mapping_With_RAPIDS_And_CLX.ipynb
@@ -49,7 +49,7 @@
     "\n",
     "import pandas as pd\n",
     "from os import path\n",
-    "import s3fs"
+    "import requests"
    ]
   },
   {
@@ -65,13 +65,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "S3_BASE_PATH = \"rapidsai-data/cyber/clx\"\n",
+    "DATA_BASE_URL = \"https://data.rapids.ai/cyber/clx/\"\n",
     "CONN_LOG = \"conn.log\"\n",
     "\n",
     "# Download Zeek conn log\n",
     "if not path.exists(CONN_LOG):\n",
-    "    fs = s3fs.S3FileSystem(anon=True)\n",
-    "    fs.get(S3_BASE_PATH + \"/\" + CONN_LOG, CONN_LOG)"
+    "    r = requests.get(DATA_BASE_URL + CONN_LOG)\n",
+    "    open(CONN_LOG, 'wb').write(r.content)"
    ]
   },
   {

--- a/notebooks/network_mapping/custream_n_graph.ipynb
+++ b/notebooks/network_mapping/custream_n_graph.ipynb
@@ -52,7 +52,7 @@
     "\n",
     "import pandas as pd\n",
     "from os import path\n",
-    "import s3fs\n",
+    "import requests\n",
     "from streamz import Stream"
    ]
   },
@@ -63,13 +63,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "S3_BASE_PATH = \"rapidsai-data/cyber/clx\"\n",
+    "DATA_BASE_URL = \"https://data.rapids.ai/cyber/clx/\"\n",
     "CONN_LOG = \"conn.log\"\n",
     "\n",
     "# Download Zeek conn log\n",
     "if not path.exists(CONN_LOG):\n",
-    "    fs = s3fs.S3FileSystem(anon=True)\n",
-    "    fs.get(S3_BASE_PATH + \"/\" + CONN_LOG, CONN_LOG)"
+    "    r = requests.get(DATA_BASE_URL + CONN_LOG)\n",
+    "    open(CONN_LOG, 'wb').write(r.content)"
    ]
   },
   {

--- a/notebooks/pii_detection/pii_detection_training_example.ipynb
+++ b/notebooks/pii_detection/pii_detection_training_example.ipynb
@@ -31,7 +31,7 @@
    "outputs": [],
    "source": [
     "from os import path\n",
-    "import s3fs\n",
+    "import requests\n",
     "import torch\n",
     "from torch.nn import BCEWithLogitsLoss\n",
     "from transformers import AutoModelForSequenceClassification, AdamW\n",
@@ -64,11 +64,11 @@
    "source": [
     "# download sample data\n",
     "PII_SAMPLE_CSV = \"pii_training_sample.csv\"\n",
-    "S3_BASE_PATH = \"rapidsai-data/cyber/pii\"\n",
+    "DATA_BASE_URL = \"https://data.rapids.ai/cyber/pii/\"\n",
     "\n",
     "if not path.exists(PII_SAMPLE_CSV):\n",
-    "    fs = s3fs.S3FileSystem(anon=True)\n",
-    "    fs.get(S3_BASE_PATH + \"/\" + PII_SAMPLE_CSV, PII_SAMPLE_CSV)"
+    "    r = requests.get(DATA_BASE_URL + PII_SAMPLE_CSV)\n",
+    "    open(PII_SAMPLE_CSV, 'wb').write(r.content)"
    ]
   },
   {


### PR DESCRIPTION
Update Rapids datasets download URL to reduce latency and costs. This PR also replace the usage of `s3fs` by `requests` to get Rapids datasets as we are not using an S3 URL anymore